### PR TITLE
wwwUser to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This tool automate TAO extension release
 
 ## Installation
 
-Please verify installation [prerequisite](#prerequisite). And run : 
+Please verify installation [prerequisite](#prerequisite). And run :
 
 ```sh
 npm i -g @oat-sa/tao-extension-release
@@ -41,6 +41,16 @@ npm link
 So the command `taoRelease` will use the sources.
 
 
+## Configuration
+
+A file named `.tao-extension-release` is created in the user directory.
+The following values can be defined in this file :
+
+ - `token` : your Github auth token
+ - `taoRoot` : the path to the root of TAO
+ - `wwwUser` : the system user used to launch PHP commands (`www-data`)
+
+
 ## System Prerequisite
 <a name="prerequisite"></a>
 
@@ -65,11 +75,16 @@ You need to have the `git` > `1.7.0` command available in your `PATH`.
 
 You also need the `php` command available in your `PATH`.
 
+#### sudo (linux and OSX)
+
+You also need the `sudo` command available in your `PATH`.
+
+
 ## Known Issues
 
 ### `Task foosass not found`
 
-Everything looks ok but you don't know why the `grunt` task is not found. If you have updated `node` or `npm` recently, you can fix this by : 
+Everything looks ok but you don't know why the `grunt` task is not found. If you have updated `node` or `npm` recently, you can fix this by :
 
 ```sh
 cd tao/views/build

--- a/index.js
+++ b/index.js
@@ -37,14 +37,15 @@ const gitClientFactory   = require('./src/git.js');
 const github             = require('./src/github.js');
 const taoInstanceFactory = require('./src/taoInstance.js');
 
-const data          = {};
+const data          = {
+    wwwUser : 'www-data'
+};
 
 //TODO CLI params
 const origin        = 'origin';
 const baseBranch    = 'develop';
 const releaseBranch = 'master';
 const branchPrefix  = 'release';
-const wwwUser       = 'www-data';
 
 var taoInstance;
 var gitClient;
@@ -96,7 +97,7 @@ config.load()
         default: data.taoRoot || process.cwd()
     }) )
     .then( result => {
-        taoInstance = taoInstanceFactory(path.resolve(result.taoRoot), false, wwwUser);
+        taoInstance = taoInstanceFactory(path.resolve(result.taoRoot), false, data.wwwUser);
         return taoInstance.isRoot();
     })
     .then( result => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-extension-release",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Helps you to release TAO extensions",
   "main": "index.js",
   "scripts": {

--- a/src/taoInstance.js
+++ b/src/taoInstance.js
@@ -24,7 +24,7 @@
 
 const fs                      = require('fs');
 const { normalize, basename } = require('path');
-const { spawn, exec }         = require('child_process');
+const { exec }                = require('child_process');
 const phpParser               = require('php-parser');
 const crossSpawn              = require('cross-spawn');
 const isWin = /^win/.test(process.platform);
@@ -340,7 +340,7 @@ module.exports = function taoInstanceFactory(rootDir = '', quiet = true, wwwUser
                 const execed = exec(command, options);
                 execed.stdout.pipe(process.stdout);
                 execed.stderr.pipe(process.stderr);
-                execed.on('exit', code => code === 0 ? resolve() : reject());
+                execed.on('exit', code => code === 0 ? resolve() : reject( new Error('Something went wrong in the translation generation')));
             });
         }
     };


### PR DESCRIPTION
During the release of an extension, one of the optional step is to "build the translations". 
From the point of view of the tool, this step means "run this php command".  the command is a for now only a `sudo -u www-data php ...` 
This PR moves the user to the config 