### PR TITLE
Feature/tao 9131/assemble steps

### DIFF
--- a/src/commands/createRelease.js
+++ b/src/commands/createRelease.js
@@ -41,3 +41,35 @@ program
     .parse(process.argv);
 
 if (program.debug) console.log(program.opts());
+
+const release = require('../release')(program.opts());
+
+async function releaseExtension() {
+    try {
+        log.title('TAO Extension Release: createRelease');
+
+        await release.loadConfig();
+        await release.selectTaoInstance();
+        await release.selectExtension();
+        await release.verifyLocalChanges();
+        await release.signTags();
+        // TODO: selectReleasingBranch();
+        // TODO: verifyReleasingBranch();
+        // TODO: mergeWithReleaseBranch();
+        await release.compileAssets();
+        await release.initialiseGithubClient();
+        await release.createPullRequest();
+        await release.extractReleaseNotes();
+        await release.mergePullRequest();
+        await release.createReleaseTag();
+        await release.createGithubRelease();
+        await release.mergeBack();
+        await release.removeReleasingBranch();
+
+        log.done('Good job!');
+    } catch (error) {
+        log.error(error);
+    }
+}
+
+releaseExtension();

--- a/src/commands/createRelease.js
+++ b/src/commands/createRelease.js
@@ -33,7 +33,7 @@ program
     .option('--release-branch <branch>', 'the target branch for the release PR', 'master')
     .option('--www-user <user>', 'the user who runs php commands', 'www-data')
     // options which fall back to user prompts if undefined
-    .option('--tao-instance <path>', 'path to local TAO instance')
+    .option('--path-to-tao <path>', 'path to local TAO instance')
     .option('--extension-to-release <extension>', 'camelCase name of the extension to release')
     .option('--version-to-release <version>', 'version of the extension to release')
     .option('--update-translations', 'indicates if we need to update translations')

--- a/src/commands/oldWayRelease.js
+++ b/src/commands/oldWayRelease.js
@@ -46,15 +46,15 @@ const release = require('../release')(program.opts());
 
 async function releaseExtension() {
     try {
-        log.title('TAO Extension Release');
+        log.title('TAO Extension Release: oldWayRelease');
 
+        // TODO: warnAboutDeprecation();
         await release.loadConfig();
         await release.selectTaoInstance();
         await release.selectExtension();
         await release.verifyLocalChanges();
         await release.signTags();
         await release.verifyBranches();
-        await release.initialiseGithubClient();
         await release.doesTagExists();
         await release.doesReleaseBranchExists();
         await release.isReleaseRequired();
@@ -62,6 +62,7 @@ async function releaseExtension() {
         await release.createReleasingBranch();
         await release.compileAssets();
         await release.updateTranslations();
+        await release.initialiseGithubClient();
         await release.createPullRequest();
         await release.extractReleaseNotes();
         await release.mergePullRequest();

--- a/src/commands/oldWayRelease.js
+++ b/src/commands/oldWayRelease.js
@@ -42,9 +42,7 @@ program
 
 if (program.debug) console.log(program.opts());
 
-const { baseBranch, branchPrefix, origin, releaseBranch, wwwUser } = program;
-
-const release = require('../release')(baseBranch, branchPrefix, origin, releaseBranch, wwwUser);
+const release = require('../release')(program.opts());
 
 async function releaseExtension() {
     try {

--- a/src/commands/oldWayRelease.js
+++ b/src/commands/oldWayRelease.js
@@ -34,7 +34,7 @@ program
     .option('--release-branch <branch>', 'the target branch for the release PR', 'master')
     .option('--www-user <user>', 'the user who runs php commands', 'www-data')
     // options which fall back to user prompts if undefined
-    .option('--tao-instance <path>', 'path to local TAO instance')
+    .option('--path-to-tao <path>', 'path to local TAO instance')
     .option('--extension-to-release <extension>', 'camelCase name of the extension to release')
     .option('--update-translations', 'indicates if we need to update translations')
     .option('--release-comment <comment>', 'comment to add to github release')

--- a/src/commands/prepareRelease.js
+++ b/src/commands/prepareRelease.js
@@ -40,3 +40,30 @@ program
     .parse(process.argv);
 
 if (program.debug) console.log(program.opts());
+
+const release = require('../release')(program.opts());
+
+async function releaseExtension() {
+    try {
+        log.title('TAO Extension Release: prepareRelease');
+
+        await release.loadConfig();
+        await release.selectTaoInstance();
+        await release.selectExtension();
+        await release.verifyLocalChanges();
+        await release.signTags();
+        await release.verifyBranches();
+        await release.doesTagExists();
+        await release.doesReleaseBranchExists();
+        await release.isReleaseRequired();
+        await release.createReleasingBranch();
+        await release.compileAssets();
+        await release.updateTranslations();
+
+        log.done('Release branch prepared, and pushed to remote. Bye!');
+    } catch (error) {
+        log.error(error);
+    }
+}
+
+releaseExtension();

--- a/src/commands/prepareRelease.js
+++ b/src/commands/prepareRelease.js
@@ -34,7 +34,7 @@ program
     .option('--release-branch <branch>', 'the target branch for the release PR', 'master')
     .option('--www-user <user>', 'the user who runs php commands', 'www-data')
     // options which fall back to user prompts if undefined
-    .option('--tao-instance <path>', 'path to local TAO instance')
+    .option('--path-to-tao <path>', 'path to local TAO instance')
     .option('--extension-to-release <extension>', 'camelCase name of the extension to release')
     .option('--update-translations', 'indicates if we need to update translations')
     .parse(process.argv);

--- a/src/release.js
+++ b/src/release.js
@@ -35,18 +35,26 @@ const taoInstanceFactory = require('./taoInstance.js');
 /**
  * Get the taoExtensionRelease
  *
- * @param {String} baseBranch - branch to release from
- * @param {String} branchPrefix - releasing branch prefix
- * @param {String} origin - git repository origin
- * @param {String} releaseBranch - branch to release to
- * @param {String} wwwUser - name of the www user
+ * @param {Object} params
+ * @param {String} [params.baseBranch] - branch to release from
+ * @param {String} [params.branchPrefix] - releasing branch prefix
+ * @param {String} [params.origin] - git repository origin
+ * @param {String} [params.releaseBranch] - branch to release to
+ * @param {String} [params.wwwUser] - name of the www user
+ * @param {String} [params.taoInstance] - path to the instance root
+ * @param {String} [params.extensionToRelease] - name of the extension
+ * @param {String} [params.versionToRelease] - version in xx.x.x format
+ * @param {Boolean} [params.updateTranslations] - should translations be included?
+ * @param {String} [params.releaseComment] - the release author's comment
  * @return {Object} - instance of taoExtensionRelease
  */
-module.exports = function taoExtensionReleaseFactory(baseBranch, branchPrefix, origin, releaseBranch, wwwUser) {
+module.exports = function taoExtensionReleaseFactory(params) {
+    const { baseBranch, branchPrefix, origin, releaseBranch, wwwUser, taoInstance,
+        extensionToRelease, versionToRelease, updateTranslations, releaseComment } = params;
+
     let data = {};
     let gitClient;
     let githubClient;
-    let taoInstance;
 
     return {
         /**

--- a/src/release.js
+++ b/src/release.js
@@ -49,12 +49,14 @@ const taoInstanceFactory = require('./taoInstance.js');
  * @return {Object} - instance of taoExtensionRelease
  */
 module.exports = function taoExtensionReleaseFactory(params) {
-    const { baseBranch, branchPrefix, origin, releaseBranch, wwwUser, taoInstance,
-        extensionToRelease, versionToRelease, updateTranslations, releaseComment } = params;
+    const { baseBranch, branchPrefix, origin, releaseBranch, wwwUser,
+        extensionToRelease, versionToRelease, updateTranslations } = params;
+    let { pathToTao, releaseComment } = params;
 
     let data = {};
     let gitClient;
     let githubClient;
+    let taoInstance;
 
     return {
         /**

--- a/src/release.js
+++ b/src/release.js
@@ -48,7 +48,7 @@ const taoInstanceFactory = require('./taoInstance.js');
  * @param {String} [params.releaseComment] - the release author's comment
  * @return {Object} - instance of taoExtensionRelease
  */
-module.exports = function taoExtensionReleaseFactory(params) {
+module.exports = function taoExtensionReleaseFactory(params = {}) {
     const { baseBranch, branchPrefix, origin, releaseBranch, wwwUser,
         extensionToRelease, versionToRelease, updateTranslations } = params;
     let { pathToTao, releaseComment } = params;

--- a/src/release.js
+++ b/src/release.js
@@ -327,8 +327,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
             const availableExtensions = await taoInstance.getExtensions();
 
             if (extension && !availableExtensions.includes(extension)) {
-                log.error(`Specified extension ${extension} not found in ${pathToTao}`);
-                log.exit();
+                log.exit(`Specified extension ${extension} not found in ${data.taoRoot}`);
             }
             else if (!extension) {
                 extension = await inquirer.prompt({

--- a/src/release.js
+++ b/src/release.js
@@ -41,7 +41,7 @@ const taoInstanceFactory = require('./taoInstance.js');
  * @param {String} [params.origin] - git repository origin
  * @param {String} [params.releaseBranch] - branch to release to
  * @param {String} [params.wwwUser] - name of the www user
- * @param {String} [params.taoInstance] - path to the instance root
+ * @param {String} [params.pathToTao] - path to the instance root
  * @param {String} [params.extensionToRelease] - name of the extension
  * @param {String} [params.versionToRelease] - version in xx.x.x format
  * @param {Boolean} [params.updateTranslations] - should translations be included?
@@ -103,7 +103,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
         async createGithubRelease() {
             log.doing(`Creating github release ${data.version}`);
 
-            // Start with CLI option
+            // Start with CLI option, if it's missing we'll prompt user
             let comment = releaseComment;
 
             if (!comment || !comment.length) {
@@ -322,7 +322,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
          * Select and initialise the extension to release
          */
         async selectExtension() {
-            // Start with CLI option
+            // Start with CLI option, if it's missing we'll prompt user
             let extension = extensionToRelease;
             const availableExtensions = await taoInstance.getExtensions();
 
@@ -355,7 +355,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
          * Select and initialise tao instance
          */
         async selectTaoInstance() {
-            // start with CLI option
+            // Start with CLI option, if it's missing we'll prompt user
             let taoRoot = pathToTao;
 
             if (!taoRoot) {
@@ -395,7 +395,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
         async updateTranslations() {
             log.doing('Translations');
 
-            // Start with CLI option
+            // Start with CLI option, if it's missing we'll prompt user
             let translation = updateTranslations;
 
             if (!translation) {

--- a/tests/unit/release/compileAssets/test.js
+++ b/tests/unit/release/compileAssets/test.js
@@ -48,7 +48,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, branchPrefix);
+})({ branchPrefix });
 
 test('should define compileAssets method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/createGithubRelease/test.js
+++ b/tests/unit/release/createGithubRelease/test.js
@@ -148,3 +148,42 @@ test('should log done message', async (t) => {
     sandbox.restore();
     t.end();
 });
+
+const releaseWithCliOption = proxyquire.noCallThru().load('../../../../src/release.js', {
+    './config.js': () => config,
+    './git.js': gitClientFactory,
+    './github.js': githubFactory,
+    './log.js': log,
+    './taoInstance.js': taoInstanceFactory,
+    inquirer,
+})({ branchPrefix, releaseBranch, releaseComment: 'my first release' });
+
+test('should use CLI release comment instead of prompting', async (t) => {
+    t.plan(4);
+
+    await releaseWithCliOption.selectTaoInstance();
+    await releaseWithCliOption.selectExtension();
+    await releaseWithCliOption.verifyBranches();
+    await releaseWithCliOption.initialiseGithubClient();
+    await releaseWithCliOption.createPullRequest();
+
+    sandbox.stub(inquirer, 'prompt');
+    {
+        await releaseWithCliOption.createGithubRelease();
+
+        t.ok(inquirer.prompt.notCalled, 'No prompt shown');
+    }
+    sandbox.restore();
+
+    sandbox.stub(githubInstance, 'release');
+    {
+        await releaseWithCliOption.createGithubRelease();
+
+        t.ok(githubInstance.release.calledOnce, 'Github release has been created');
+        t.ok(githubInstance.release.calledWith(`v${version}`), 'Github release has been created from apropriate tag');
+        t.ok(githubInstance.release.calledWith(`v${version}`, sinon.match(/^my first release/)), 'Github release has been created with CLI comment');
+    }
+    sandbox.restore();
+
+    t.end();
+});

--- a/tests/unit/release/createGithubRelease/test.js
+++ b/tests/unit/release/createGithubRelease/test.js
@@ -54,7 +54,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, branchPrefix, null, releaseBranch);
+})({ branchPrefix, releaseBranch });
 
 test('should define createGithubRelease method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/createPullRequest/test.js
+++ b/tests/unit/release/createPullRequest/test.js
@@ -52,7 +52,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, branchPrefix, null, releaseBranch);
+})({ branchPrefix, releaseBranch });
 
 test('should define createPullRequest method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/createReleaseTag/test.js
+++ b/tests/unit/release/createReleaseTag/test.js
@@ -45,7 +45,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, null, null, releaseBranch);
+})({ releaseBranch });
 
 test('should define createReleaseTag method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/createReleasingBranch/test.js
+++ b/tests/unit/release/createReleasingBranch/test.js
@@ -45,7 +45,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, branchPrefix);
+})({ branchPrefix });
 
 test('should define createReleasingBranch method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/doesReleaseBranchExists/test.js
+++ b/tests/unit/release/doesReleaseBranchExists/test.js
@@ -44,7 +44,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, branchPrefix);
+})({ branchPrefix });
 
 test('should define doesReleaseBranchExists method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/extractReleaseNotes/test.js
+++ b/tests/unit/release/extractReleaseNotes/test.js
@@ -54,7 +54,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, branchPrefix, null, releaseBranch);
+})({ branchPrefix, releaseBranch });
 
 test('should define extractReleaseNotes method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/isReleaseRequired/test.js
+++ b/tests/unit/release/isReleaseRequired/test.js
@@ -43,7 +43,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(baseBranch, null, null, releaseBranch);
+})({ baseBranch, releaseBranch });
 
 test('should define isReleaseRequired method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/mergeBack/test.js
+++ b/tests/unit/release/mergeBack/test.js
@@ -42,7 +42,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './taoInstance.js': taoInstanceFactory,
     './log.js': log,
     inquirer,
-})(baseBranch, null, null, releaseBranch);
+})({ baseBranch, releaseBranch });
 
 test('should define mergeBack method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/mergePullRequest/test.js
+++ b/tests/unit/release/mergePullRequest/test.js
@@ -55,7 +55,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './taoInstance.js': taoInstanceFactory,
     inquirer,
     opn,
-})(null, branchPrefix, null, releaseBranch);
+})({ branchPrefix, releaseBranch });
 
 test('should define mergePullRequest method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/removeReleasingBranch/test.js
+++ b/tests/unit/release/removeReleasingBranch/test.js
@@ -45,7 +45,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, branchPrefix);
+})({ branchPrefix });
 
 test('should define removeReleasingBranch method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/selectExtension/test.js
+++ b/tests/unit/release/selectExtension/test.js
@@ -32,7 +32,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './git.js': gitClientFactory,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, null, origin);
+})({ origin });
 
 test('should define selectExtension method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/selectTaoInstance/test.js
+++ b/tests/unit/release/selectTaoInstance/test.js
@@ -29,7 +29,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, null, null, null, wwwUser);
+})({ wwwUser });
 
 test('should define selectTaoInstance method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/updateTranslations/test.js
+++ b/tests/unit/release/updateTranslations/test.js
@@ -49,7 +49,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(null, branchPrefix);
+})({ branchPrefix });
 
 test('should define updateTranslations method on release instance', (t) => {
     t.plan(1);

--- a/tests/unit/release/verifyBranches/test.js
+++ b/tests/unit/release/verifyBranches/test.js
@@ -43,7 +43,7 @@ const release = proxyquire.noCallThru().load('../../../../src/release.js', {
     './log.js': log,
     './taoInstance.js': taoInstanceFactory,
     inquirer,
-})(baseBranch, null, null, releaseBranch);
+})({ baseBranch, releaseBranch });
 
 test('should define verifyBranches method on release instance', (t) => {
     t.plan(1);


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-9131

- added list of steps to `prepareRelease` and `createRelease` commands
- refactored `src/release.js` arguments into a single object
- implemented checking of CLI options to bypass user prompts
- renamed one CLI option to `path-to-tao` for better internal naming
- some unit tests added

I will still add more unit tests for the new code. But the refactored code for the task is ready to be reviewed.

Eventually I will add instructions here for testing with a real extension. But for now:
```
npm i
npm link
npm run test
taoRelease oldWayRelease [options]
taoRelease prepareRelease [options]
taoRelease createRelease [options]
```