### PR TITLE
Feature/tao 9127/old way release depecreation warning

### DIFF
--- a/src/commands/oldWayRelease.js
+++ b/src/commands/oldWayRelease.js
@@ -48,7 +48,7 @@ async function releaseExtension() {
     try {
         log.title('TAO Extension Release: oldWayRelease');
 
-        // TODO: await release.warnAboutDeprecation();
+        await release.warnAboutDeprecation();
         await release.loadConfig();
         await release.selectTaoInstance();
         await release.selectExtension();

--- a/src/release.js
+++ b/src/release.js
@@ -59,6 +59,23 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
     let taoInstance;
 
     return {
+
+        /**
+         * Prompt user if he really want to use deprecated way to do the release
+         */
+        async warnAboutDeprecation() {
+            const { go } = await inquirer.prompt({
+                type: 'confirm',
+                name: 'go',
+                message: 'This release process is [deprecated]. Are you sure you want to continue?',
+                default: false
+            });
+
+            if (!go) {
+                log.exit();
+            }
+        },
+
         /**
          * Compile and publish extension assets
          */

--- a/src/release.js
+++ b/src/release.js
@@ -65,14 +65,14 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
          * Prompt user if he really want to use deprecated way to do the release
          */
         async warnAboutDeprecation() {
-            const { go } = await inquirer.prompt({
+            const { isOldWayReleaseSelected } = await inquirer.prompt({
                 type: 'confirm',
-                name: 'go',
+                name: 'isOldWayReleaseSelected',
                 message: 'This release process is [deprecated]. Are you sure you want to continue?',
                 default: false
             });
 
-            if (!go) {
+            if (!isOldWayReleaseSelected) {
                 log.exit();
             }
         },

--- a/tests/unit/release/warnAboutDeprecation/test.js
+++ b/tests/unit/release/warnAboutDeprecation/test.js
@@ -1,0 +1,90 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 Open Assessment Technologies SA;
+ */
+
+/**
+ * Unit test the selectReleasingBranch method of module src/release.js
+ *
+ * @author Ricardo Proença <ricardo@taotesting.com>
+ */
+
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const test = require('tape');
+
+const sandbox = sinon.sandbox.create();
+
+const config = {
+    write: () => { }
+};
+
+const log = {
+    exit: () => { }
+};
+
+const inquirer = {
+    prompt: () => {},
+};
+
+const release = proxyquire.noCallThru().load('../../../../src/release.js', {
+    './config.js': () => config,
+    './git.js': {},
+    './log.js': log,
+    './taoInstance.js': {},
+    inquirer,
+})();
+
+test('should define warnAboutDeprecation method on release instance', (t) => {
+    t.plan(1);
+
+    t.ok(typeof release.warnAboutDeprecation === 'function', 'The release instance has warnAboutDeprecation method');
+
+    t.end();
+});
+
+test('should prompt to confirm release', async (t) => {
+    t.plan(4);
+
+    sandbox.stub(inquirer, 'prompt').callsFake(({ type, name, message }) => {
+        t.equal(type, 'confirm', 'The type should be "confirm"');
+        t.equal(name, 'isOldWayReleaseSelected', 'The param name should be isOldWayReleaseSelected');
+        t.equal(message, 'This release process is [deprecated]. Are you sure you want to continue?', 'Should disaplay appropriate message');
+
+        return { go: true };
+    });
+
+    await release.warnAboutDeprecation();
+
+    t.equal(inquirer.prompt.callCount, 1, 'Prompt has been initialised');
+
+    sandbox.restore();
+    t.end();
+});
+
+test('should log exit if release was not confirmed', async (t) => {
+    t.plan(1);
+
+    sandbox.stub(inquirer, 'prompt').returns({ go: false });
+    sandbox.stub(log, 'exit');
+
+    await release.warnAboutDeprecation();
+
+    t.equal(log.exit.callCount, 1, 'Exit has been logged');
+
+    sandbox.restore();
+    t.end();
+});


### PR DESCRIPTION
**Related to task:** 
https://oat-sa.atlassian.net/browse/TAO-9127

**Description:**
Since the old release process is deprecated, there should be appropriated message if user tries to do release in old way

**How to test:**
`node .\index.js oldWayRelease`

**Unit tests:**
No unit tests