### PR TITLE
Feature/tao 9129/verify release branch

### DIFF
--- a/src/commands/createRelease.js
+++ b/src/commands/createRelease.js
@@ -54,7 +54,7 @@ async function releaseExtension() {
         await release.verifyLocalChanges();
         await release.signTags();
         await release.selectReleasingBranch();
-        // TODO: await release.verifyReleasingBranch();
+        await release.verifyReleasingBranch();
         // TODO: await release.mergeWithReleaseBranch();
         // await release.compileAssets();
         // await release.initialiseGithubClient();

--- a/src/release.js
+++ b/src/release.js
@@ -527,7 +527,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
             // Cross check releasing branch wth release branch and make sure new version is highest
             await gitClient.checkout(releaseBranch);
             const releaseBranchManifest = await taoInstance.parseManifest(`${data.extension.path}/manifest.php`);
-            if (compareVersions(releasingBranchManifest.version, releaseBranchManifest.version) == 1 ) {
+            if (compareVersions(releasingBranchManifest.version, releaseBranchManifest.version) === 1 ) {
                 log.done(`Branch ${data.releasingBranch} is valid.`);
             } else {
                 log.exit(`Branch '${data.releasingBranch}' cannot be released because its manifest version (${data.version}) is not greater than the manifest version of '${releaseBranch}' (${releaseBranchManifest.version}).`);

--- a/src/release.js
+++ b/src/release.js
@@ -518,7 +518,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
             // Cross check releasing branch version with manifest version
             await gitClient.checkout(data.releasingBranch);
             const releasingBranchManifest = await taoInstance.parseManifest(`${data.extension.path}/manifest.php`);
-            if (compareVersions(releasingBranchManifest.version, data.version) == 0 ) {
+            if (compareVersions(releasingBranchManifest.version, data.version) === 0 ) {
                 log.doing(`Branch ${data.releasingBranch} has valid manifest.`);
             } else {
                 log.exit(`Mismatch versions found between branch '${data.releasingBranch}' and manifest version '${releasingBranchManifest.version}'.`);

--- a/src/release.js
+++ b/src/release.js
@@ -521,7 +521,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
             if (compareVersions(releasingBranchManifest.version, data.version) === 0 ) {
                 log.doing(`Branch ${data.releasingBranch} has valid manifest.`);
             } else {
-                log.exit(`Branch '${data.releasingBranch}' cannot be released because its branch name does not match its own manifest version (${releasingBranchManifest.version}).`);
+                log.exit(`Branch '${data.releasingBranch}' cannot be released because it's branch name does not match its own manifest version (${releasingBranchManifest.version}).`);
             }
 
             // Cross check releasing branch wth release branch and make sure new version is highest

--- a/src/release.js
+++ b/src/release.js
@@ -521,7 +521,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
             if (compareVersions(releasingBranchManifest.version, data.version) === 0 ) {
                 log.doing(`Branch ${data.releasingBranch} has valid manifest.`);
             } else {
-                log.exit(`Mismatch versions found between branch '${data.releasingBranch}' and manifest version '${releasingBranchManifest.version}'.`);
+                log.exit(`Branch '${data.releasingBranch}' cannot be released because its branch name does not match its own manifest version (${releasingBranchManifest.version}).`);
             }
 
             // Cross check releasing branch wth release branch and make sure new version is highest
@@ -530,7 +530,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
             if (compareVersions(releasingBranchManifest.version, releaseBranchManifest.version) == 1 ) {
                 log.done(`Branch ${data.releasingBranch} is valid.`);
             } else {
-                log.exit(`Branch '${data.releasingBranch}' is not valid because version is not greater than '${releaseBranch}' (${releaseBranchManifest.version}).`);
+                log.exit(`Branch '${data.releasingBranch}' cannot be released because its manifest version (${data.version}) is not greater than the manifest version of '${releaseBranch}' (${releaseBranchManifest.version}).`);
             }
         },
 

--- a/tests/unit/release/verifyReleasingBranch/test.js
+++ b/tests/unit/release/verifyReleasingBranch/test.js
@@ -1,0 +1,136 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 Open Assessment Technologies SA;
+ */
+
+/**
+ * Unit test the verifyReleasingBranch method of module src/release.js
+ *
+ * @author Ricardo Proença <ricardo@taotesting.com>
+ */
+
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const test = require('tape');
+
+const sandbox = sinon.sandbox.create();
+
+const config = {
+    write: () => { },
+};
+
+const gitClientInstance = {
+    getLocalBranches: () => {},
+    fetch: () => { },
+};
+
+const gitClientFactory = sandbox.stub().callsFake(() => gitClientInstance);
+
+const log = {
+    doing: () => { },
+    exit: () => { },
+    error: () => { },
+    done: () => { }
+};
+
+const taoRoot = 'testRoot';
+const extension = 'testExtension';
+
+const inquirer = {
+    prompt: () => ({ extension, pull: true, taoRoot }),
+};
+
+const taoInstance = {
+    getExtensions: () => [],
+    isInstalled: () => true,
+    isRoot: () => ({ root: true, dir: taoRoot }),
+    parseManifest: () => ({}),
+};
+
+const taoInstanceFactory = sandbox.stub().callsFake(() => taoInstance);
+
+const releaseOptions = {
+    branchPrefix: 'release',
+    origin: 'origin',
+    versionToRelease: '0.9.0'
+};
+
+const release = proxyquire.noCallThru().load('../../../../src/release.js', {
+    './config.js': () => config,
+    './git.js': gitClientFactory,
+    './log.js': log,
+    './taoInstance.js': taoInstanceFactory,
+    inquirer,
+})(releaseOptions);
+
+test('should define selectReleasingBranch method on release instance', (t) => {
+    t.plan(1);
+    t.ok(typeof release.selectReleasingBranch === 'function', 'The release instance has selectReleasingBranch method');
+    t.end();
+});
+
+test('Version provided but no branches found', async (t) => {
+    t.plan(2);
+
+    await release.selectTaoInstance();
+    await release.selectExtension();
+
+    sandbox.stub(gitClientInstance, 'fetch');
+    sandbox.stub(gitClientInstance, 'getLocalBranches').returns([
+        'some-branch-with-weird-name',
+        'remotes/origin/release-0.6.0',
+        'remotes/origin/release-0.7.0',
+        'remotes/origin/release-0.8.0',
+        'release-0.9.0',
+        'remotes/origin/release_0.9.0',
+    ]);
+    sandbox.stub(log, 'exit');
+
+    await release.selectReleasingBranch();
+
+    t.equal(log.exit.callCount, 1, 'Exit message has been logged');
+    t.ok(log.exit.calledWith('Cannot find any branch with valid version.'), 'Exit message has been logged with apropriate message');
+
+    sandbox.restore();
+    t.end();
+});
+
+test('version provided and found 1 branch', async (t) => {
+    t.plan(2);
+
+    await release.selectTaoInstance();
+    await release.selectExtension();
+
+    sandbox.stub(gitClientInstance, 'fetch');
+    sandbox.stub(gitClientInstance, 'getLocalBranches').returns([
+        'some-branch-with-weird-name',
+        'remotes/origin/release-0.7.0',
+        'remotes/origin/release-0.8.0',
+        'remotes/origin/release-0.9.0',
+        'remotes/origin/release-0.9.0-alpha',
+        'remotes/origin/release-0.9.0-beta'
+    ]);
+
+    sandbox.stub(log, 'done');
+
+    await release.selectReleasingBranch();
+
+    t.equal(log.done.callCount, 1, 'Done message has been logged');
+    t.ok(log.done.calledWith('Branch remotes/origin/release-0.9.0 is selected.'), 'Done message has been logged with apropriate message');
+
+    sandbox.restore();
+    t.end();
+});

--- a/tests/unit/release/verifyReleasingBranch/test.js
+++ b/tests/unit/release/verifyReleasingBranch/test.js
@@ -104,7 +104,7 @@ test('Releasing branch has different version than manifest', async (t) => {
     await release.verifyReleasingBranch();
 
     t.equal(log.exit.callCount, 2, 'Exit message has been logged');
-    t.ok(log.exit.calledWith(`Mismatch versions found between branch '${releasingBranch}' and manifest version '0.7.0'.`), 'Exit message has been logged with apropriate message');
+    t.ok(log.exit.calledWith(`Branch '${releasingBranch}' cannot be released because its branch name does not match its own manifest version (0.7.0).`), 'Exit message has been logged with apropriate message');
 
     sandbox.restore();
     t.end();
@@ -158,8 +158,7 @@ test('Releasing branch is valid but is less than release branch version', async 
     t.ok(log.doing.calledWith(`Branch ${releasingBranch} has valid manifest.`), 'Doing message has been logged with apropriate message');
 
     t.equal(log.exit.callCount, 1, 'Exit message has been logged');
-    t.ok(log.exit.calledWith(`Branch '${releasingBranch}' is not valid because version is not greater than '${releaseBranch}' (0.10.0).`), 'Exit message has been logged with apropriate message');
-
+    t.ok(log.exit.calledWith(`Branch '${releasingBranch}' cannot be released because its manifest version (0.9.0) is not greater than the manifest version of '${releaseBranch}' (0.10.0).`), 'Exit message has been logged with apropriate message');
     sandbox.restore();
     t.end();
 });

--- a/tests/unit/release/verifyReleasingBranch/test.js
+++ b/tests/unit/release/verifyReleasingBranch/test.js
@@ -104,7 +104,7 @@ test('Releasing branch has different version than manifest', async (t) => {
     await release.verifyReleasingBranch();
 
     t.equal(log.exit.callCount, 2, 'Exit message has been logged');
-    t.ok(log.exit.calledWith(`Branch '${releasingBranch}' cannot be released because its branch name does not match its own manifest version (0.7.0).`), 'Exit message has been logged with apropriate message');
+    t.ok(log.exit.calledWith(`Branch '${releasingBranch}' cannot be released because it's branch name does not match its own manifest version (0.7.0).`), 'Exit message has been logged with apropriate message');
 
     sandbox.restore();
     t.end();


### PR DESCRIPTION
**Related to task:** 
https://oat-sa.atlassian.net/browse/TAO-9129

**Description:**
Make sure that the version that we are going to release is bigger than current release branch version.

**How to test:**
`node .\index.js createRelease`
`node .\index.js createRelease --version-to-release XX.X.X`

**Unit tests:**
`node .\tests\unit\release\verifyReleasingBranch\test.js`