### PR TITLE
Feature/tao 9130/merge with release branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,6 +1003,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -3488,7 +3489,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -4582,11 +4584,26 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-git": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.77.0.tgz",
-      "integrity": "sha1-UmU3RwuUbl9vk9ED71S0aUlgCTk=",
+      "version": "1.126.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.126.0.tgz",
+      "integrity": "sha512-47mqHxgZnN8XRa9HbpWprzUv3Ooqz9RY/LSZgvA7jCkW8jcwLahMz7LKugY91KZehfG0sCVPtgXiU72hd6b1Bw==",
       "requires": {
-        "debug": "^2.6.7"
+        "debug": "^4.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "sinon": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test:dev": "nodemon -e js --watch tests --watch src --delay 1 --exec 'npm run test'",
     "test:cov": "nyc npm test",
     "test:cov:html": "nyc report --reporter=lcov && open-cli coverage/lcov-report/index.html",
-    "test": "tape 'tests/**/test.js' | tap-diff || true",
+    "test": "tape tests/**/test.js | tap-diff || true",
     "lint": "eslint index.js src/*.js tests/**/test.js"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "octonode": "^0.9.4",
     "opn": "^5.1.0",
     "php-parser": "^2.0.7",
-    "simple-git": "^1.77.0",
+    "simple-git": "^1.126.0",
     "update-notifier": "^2.3.0"
   },
   "engine": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Helps you to release TAO extensions",
   "main": "index.js",
   "scripts": {
-    "test:dev": "nodemon -e js --watch tests --watch src --delay 1 --exec 'npm run test'",
+    "test:dev": "nodemon -e js --watch tests --watch src --delay 1 --exec npm run test",
     "test:cov": "nyc npm test",
     "test:cov:html": "nyc report --reporter=lcov && open-cli coverage/lcov-report/index.html",
     "test": "tape tests/**/test.js | tap-diff || true",

--- a/src/commands/createRelease.js
+++ b/src/commands/createRelease.js
@@ -55,7 +55,7 @@ async function releaseExtension() {
         await release.signTags();
         await release.selectReleasingBranch();
         await release.verifyReleasingBranch();
-        // TODO: await release.mergeWithReleaseBranch();
+        await release.mergeWithReleaseBranch();
         await release.compileAssets();
         await release.initialiseGithubClient();
         await release.createPullRequest();

--- a/src/git.js
+++ b/src/git.js
@@ -224,14 +224,14 @@ module.exports = function gitFactory(repository = '', origin = 'origin') {
          * @param {String} targetBranch - the branch to merge into the current branch
          * @returns {Promise}
          */
-        async merge(targetBranch){
+        merge(targetBranch){
             return git(repository).merge([targetBranch]);
         },
 
         /**
          * Aborts a merge
          */
-        async abortMerge(targetBranch) {
+        abortMerge(targetBranch) {
             return git(repository).merge([targetBranch], {'--abort': true});
         },
 

--- a/src/git.js
+++ b/src/git.js
@@ -229,6 +229,13 @@ module.exports = function gitFactory(repository = '', origin = 'origin') {
         },
 
         /**
+         * Aborts a merge
+         */
+        async abortMerge(targetBranch) {
+            return git(repository).merge([targetBranch], {'--abort': true});
+        },
+
+        /**
          * Commit and push every change on the current branch
          * @param {String} branchName - name of the branch to push to
          * @param {String} comment - commit comment

--- a/src/git.js
+++ b/src/git.js
@@ -209,6 +209,26 @@ module.exports = function gitFactory(repository = '', origin = 'origin') {
         },
 
         /**
+         * Push a branch to the given remote
+         * @param {String} origin - name of the remote
+         * @param {String} branchName - name of the branch to push to
+         * @returns {Promise}
+         */
+        push(origin, branchName) {
+            return git(repository).push(origin, branchName);
+        },
+
+        /**
+         * Merge targetBranch into your current tbranch
+         *
+         * @param {String} targetBranch - the branch to merge into the current branch
+         * @returns {Promise}
+         */
+        async merge(targetBranch){
+            return git(repository).merge([targetBranch]);
+        },
+
+        /**
          * Commit and push every change on the current branch
          * @param {String} branchName - name of the branch to push to
          * @param {String} comment - commit comment

--- a/src/release.js
+++ b/src/release.js
@@ -356,19 +356,24 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
 
                 log.done(`'${releaseBranch}' merged into '${branchPrefix}-${data.version}'.`);
             } catch (err) {
-                log.warn('Please resolve the conflicts and complete the merge manually (including making the merge commit).');
+                // error is about merging conflicts
+                if (err.stack && err.message && err.message.startsWith('CONFLICTS:')) {
+                    log.warn('Please resolve the conflicts and complete the merge manually (including making the merge commit).');
 
-                const mergeDone = await this.promptToResolveConflicts();
-                if (mergeDone) {
-                    if (await gitClient.hasLocalChanges()) {
-                        log.exit(`Cannot push changes because local branch '${data.releasingBranch}' still has changes to commit.`);
+                    const mergeDone = await this.promptToResolveConflicts();
+                    if (mergeDone) {
+                        if (await gitClient.hasLocalChanges()) {
+                            log.exit(`Cannot push changes because local branch '${data.releasingBranch}' still has changes to commit.`);
+                        } else {
+                            // await gitClient.push(origin, data.releasingBranch);
+                            log.done(`'${releaseBranch}' merged into '${branchPrefix}-${data.version}'.`);
+                        }
                     }
-                    await gitClient.push(origin, data.releasingBranch);
-                    log.done(`'${releaseBranch}' merged into '${branchPrefix}-${data.version}'.`);
-                    return;
+                    await gitClient.abortMerge([releaseBranch]);
+                    log.exit();
+                } else {
+                    log.exit(`An error occurred: ${err}`);
                 }
-                await gitClient.abortMerge([releaseBranch]);
-                log.exit();
             }
         },
 

--- a/src/release.js
+++ b/src/release.js
@@ -341,16 +341,16 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
         async mergeWithReleaseBranch() {
             log.doing(`Merging '${releaseBranch}' into '${data.releasingBranch}'.`);
 
+            // checkout master
+            await gitClient.checkout(releaseBranch);
+
+            // pull master
+            await gitClient.pull(releaseBranch);
+
+            // checkout releasingBranch
+            await gitClient.checkout(`${branchPrefix}-${data.version}`);
+
             try {
-                // checkout master
-                await gitClient.checkout(releaseBranch);
-
-                // pull master
-                await gitClient.pull(releaseBranch);
-
-                // checkout releasingBranch
-                await gitClient.checkout(`${branchPrefix}-${data.version}`);
-
                 // merge release branch into releasingBranch
                 await gitClient.merge([releaseBranch]);
 
@@ -365,7 +365,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
                         if (await gitClient.hasLocalChanges()) {
                             log.exit(`Cannot push changes because local branch '${data.releasingBranch}' still has changes to commit.`);
                         } else {
-                            // await gitClient.push(origin, data.releasingBranch);
+                            await gitClient.push(origin, data.releasingBranch);
                             log.done(`'${releaseBranch}' merged into '${branchPrefix}-${data.version}'.`);
                         }
                     }

--- a/src/release.js
+++ b/src/release.js
@@ -581,6 +581,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
                         log.exit(`Cannot push changes because local branch '${data.releasingBranch}' still has changes to commit.`);
                     }
                     await gitClient.push(origin, data.releasingBranch);
+                    log.done(`'${releaseBranch}' merged into '${branchPrefix}-${data.version}'.`);
                     return;
                 }
                 await gitClient.abortMerge([releaseBranch]);

--- a/src/release.js
+++ b/src/release.js
@@ -357,7 +357,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
                 log.done(`'${releaseBranch}' merged into '${branchPrefix}-${data.version}'.`);
             } catch (err) {
                 // error is about merging conflicts
-                if (err.stack && err.stack.startsWith('Error: CONFLICTS:') && err.message && err.message.startsWith('CONFLICTS:')) {
+                if (err && err.message && err.message.startsWith('CONFLICTS:')) {
                     log.warn('Please resolve the conflicts and complete the merge manually (including making the merge commit).');
 
                     const mergeDone = await this.promptToResolveConflicts();

--- a/src/release.js
+++ b/src/release.js
@@ -571,7 +571,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
                 // merge release branch into releasingBranch
                 await gitClient.merge([releaseBranch]);
 
-                log.done(`'${releaseBranch}' merged into '${data.releasingBranch}'.`);
+                log.done(`'${releaseBranch}' merged into '${branchPrefix}-${data.version}'.`);
             } catch (err) {
                 log.warn('Please resolve the conflicts and complete the merge manually (including making the merge commit).');
 

--- a/src/release.js
+++ b/src/release.js
@@ -609,12 +609,14 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
          * @returns {Promise}
          */
         async promptToResolveConflicts() {
-            return await inquirer.prompt({
-                name: 'resolveConflicts',
+            const { isMergeDone } = await inquirer.prompt({
+                name: 'isMergeDone',
                 type: 'confirm',
                 message: `Has the merge been completed manually? I need to push the branch to ${origin}.`,
                 default: false
             });
+
+            return isMergeDone;
         }
     };
 };

--- a/src/release.js
+++ b/src/release.js
@@ -570,6 +570,8 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
 
                 // merge release branch into releasingBranch
                 await gitClient.merge([releaseBranch]);
+
+                log.done(`'${releaseBranch}' merged into '${data.releasingBranch}'.`);
             } catch (err) {
                 log.warn('Please resolve the conflicts and complete the merge manually (including making the merge commit).');
 

--- a/src/release.js
+++ b/src/release.js
@@ -551,11 +551,16 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
             }
         },
 
+
+        /**
+         * Merge release branch into releasing branch and ask user to resolve conflicts manually if any
+         */
         async mergeWithReleaseBranch() {
             log.doing(`Merging '${releaseBranch}' into '${data.releasingBranch}'.`);
 
             // checkout master
             await gitClient.checkout(releaseBranch);
+
             // pull master
             await gitClient.pull(releaseBranch);
 

--- a/src/release.js
+++ b/src/release.js
@@ -576,6 +576,19 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
             });
 
             return { branch, version };
+        },
+
+        /**
+         * Show a prompt to pause the program and make them confirm they have resolved conflicts.
+         * @returns {Promise}
+         */
+        async promptToResolveConflicts() {
+            return await inquirer.prompt({
+                name: 'resolveConflicts',
+                type: 'confirm',
+                message: `Has the merge been completed manually? I need to push the branch to ${origin}.`,
+                default: false
+            });
         }
     };
 };

--- a/src/release.js
+++ b/src/release.js
@@ -558,17 +558,19 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
         async mergeWithReleaseBranch() {
             log.doing(`Merging '${releaseBranch}' into '${data.releasingBranch}'.`);
 
-            // checkout master
-            await gitClient.checkout(releaseBranch);
+            try {
+                // checkout master
+                await gitClient.checkout(releaseBranch);
 
-            // pull master
-            await gitClient.pull(releaseBranch);
+                // pull master
+                await gitClient.pull(releaseBranch);
 
-            // checkout releasingBranch
-            await gitClient.checkout(`${branchPrefix}-${data.version}`);
+                // checkout releasingBranch
+                await gitClient.checkout(`${branchPrefix}-${data.version}`);
 
-            // merge master releasingBranch
-            await gitClient.merge([releaseBranch]).catch( async () => {
+                // merge release branch into releasingBranch
+                await gitClient.merge([releaseBranch]);
+            } catch (err) {
                 log.warn('Please resolve the conflicts and complete the merge manually (including making the merge commit).');
 
                 const mergeDone = await this.promptToResolveConflicts();
@@ -581,7 +583,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
                 }
                 await gitClient.abortMerge([releaseBranch]);
                 log.exit();
-            });
+            }
         },
 
         // Private methods

--- a/tests/unit/release/mergeWithReleaseBranch/test.js
+++ b/tests/unit/release/mergeWithReleaseBranch/test.js
@@ -17,7 +17,7 @@
  */
 
 /**
- * Unit test the verifyReleasingBranch method of module src/release.js
+ * Unit test the mergeWithReleaseBranch method of module src/release.js
  *
  * @author Ricardo Proença <ricardo@taotesting.com>
  */

--- a/tests/unit/release/mergeWithReleaseBranch/test.js
+++ b/tests/unit/release/mergeWithReleaseBranch/test.js
@@ -103,9 +103,7 @@ test('Merging release branch into releasing branch, no conflicts found', async (
 
     await release.selectReleasingBranch();
 
-    const callback = sandbox.stub(taoInstance, 'parseManifest');
-    callback.onCall(0).returns({ version: '0.9.0'});
-    callback.onCall(1).returns({ version: '0.8.0'});
+    sandbox.stub(taoInstance, 'parseManifest').returns({ version: '0.9.0'});
 
     await release.verifyReleasingBranch();
 
@@ -145,9 +143,7 @@ test('Merging release branch into releasing branch, found conflicts and user abo
 
     await release.selectReleasingBranch();
 
-    const callback = sandbox.stub(taoInstance, 'parseManifest');
-    callback.onCall(0).returns({ version: '0.9.0'});
-    callback.onCall(1).returns({ version: '0.8.0'});
+    sandbox.stub(taoInstance, 'parseManifest').returns({ version: '0.9.0'});
 
     await release.verifyReleasingBranch();
 
@@ -161,7 +157,7 @@ test('Merging release branch into releasing branch, found conflicts and user abo
 
     sandbox.stub(gitClientInstance, 'checkout');
     sandbox.stub(gitClientInstance, 'pull');
-    sandbox.stub(gitClientInstance, 'merge').throws();
+    sandbox.stub(gitClientInstance, 'merge').throws({stack : 'Error: CONFLICTS:', message: 'CONFLICTS:'});
     sandbox.stub(gitClientInstance, 'abortMerge');
     sandbox.stub(log, 'doing');
     sandbox.stub(log, 'warn');
@@ -201,9 +197,7 @@ test('Merging release branch into releasing branch, found conflicts and user pro
 
     await release.selectReleasingBranch();
 
-    const callback = sandbox.stub(taoInstance, 'parseManifest');
-    callback.onCall(0).returns({ version: '0.9.0'});
-    callback.onCall(1).returns({ version: '0.8.0'});
+    sandbox.stub(taoInstance, 'parseManifest').returns({ version: '0.9.0'});
 
     await release.verifyReleasingBranch();
 
@@ -217,7 +211,7 @@ test('Merging release branch into releasing branch, found conflicts and user pro
 
     sandbox.stub(gitClientInstance, 'checkout');
     sandbox.stub(gitClientInstance, 'pull');
-    sandbox.stub(gitClientInstance, 'merge').throws();
+    sandbox.stub(gitClientInstance, 'merge').throws({stack : 'Error: CONFLICTS:', message: 'CONFLICTS:'});
     sandbox.stub(gitClientInstance, 'hasLocalChanges').returns(false);
     sandbox.stub(gitClientInstance, 'push');
 
@@ -262,9 +256,7 @@ test('Merging release branch into releasing branch, found conflicts and user pro
 
     await release.selectReleasingBranch();
 
-    const callback = sandbox.stub(taoInstance, 'parseManifest');
-    callback.onCall(0).returns({ version: '0.9.0'});
-    callback.onCall(1).returns({ version: '0.8.0'});
+    sandbox.stub(taoInstance, 'parseManifest').returns({ version: '0.9.0'});
 
     await release.verifyReleasingBranch();
 
@@ -278,7 +270,7 @@ test('Merging release branch into releasing branch, found conflicts and user pro
 
     sandbox.stub(gitClientInstance, 'checkout');
     sandbox.stub(gitClientInstance, 'pull');
-    sandbox.stub(gitClientInstance, 'merge').throws();
+    sandbox.stub(gitClientInstance, 'merge').throws({stack : 'Error: CONFLICTS:', message: 'CONFLICTS:'});
     sandbox.stub(gitClientInstance, 'hasLocalChanges').returns(true);
     sandbox.stub(gitClientInstance, 'push');
 

--- a/tests/unit/release/mergeWithReleaseBranch/test.js
+++ b/tests/unit/release/mergeWithReleaseBranch/test.js
@@ -1,0 +1,164 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 Open Assessment Technologies SA;
+ */
+
+/**
+ * Unit test the verifyReleasingBranch method of module src/release.js
+ *
+ * @author Ricardo Proença <ricardo@taotesting.com>
+ */
+
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const test = require('tape');
+
+const sandbox = sinon.sandbox.create();
+
+const config = {
+    write: () => { },
+};
+
+const gitClientInstance = {
+    getLocalBranches: () => {},
+    fetch: () => { },
+    checkout: () => { }
+};
+
+const gitClientFactory = sandbox.stub().callsFake(() => gitClientInstance);
+
+const log = {
+    doing: () => { },
+    exit: () => { },
+    error: () => { },
+    done: () => { }
+};
+
+const taoRoot = 'testRoot';
+const extension = 'testExtension';
+
+const inquirer = {
+    prompt: () => ({ extension, pull: true, taoRoot }),
+};
+
+const taoInstance = {
+    getExtensions: () => [],
+    isInstalled: () => true,
+    isRoot: () => ({ root: true, dir: taoRoot }),
+    parseManifest: () => ({}),
+};
+
+const taoInstanceFactory = sandbox.stub().callsFake(() => taoInstance);
+
+const releaseOptions = {
+    branchPrefix: 'release',
+    origin: 'origin',
+    versionToRelease: '0.9.0',
+    releaseBranch: 'master'
+};
+
+const release = proxyquire.noCallThru().load('../../../../src/release.js', {
+    './config.js': () => config,
+    './git.js': gitClientFactory,
+    './log.js': log,
+    './taoInstance.js': taoInstanceFactory,
+    inquirer,
+})(releaseOptions);
+
+const releasingBranch = 'remotes/origin/release-0.9.0';
+const releaseBranch = 'master';
+
+test('should define mergeWithReleaseBranch method on release instance', (t) => {
+    t.plan(1);
+    t.ok(typeof release.mergeWithReleaseBranch === 'function', 'The release instance has mergeWithReleaseBranch method');
+    t.end();
+});
+
+// test('Releasing branch has different version than manifest', async (t) => {
+//     t.plan(2);
+
+//     sandbox.stub(gitClientInstance, 'fetch');
+//     sandbox.stub(gitClientInstance, 'getLocalBranches').returns([releasingBranch]);
+//     sandbox.stub(log, 'exit');
+
+//     const callback = sandbox.stub(taoInstance, 'parseManifest');
+//     callback.onCall(0).returns({ version: '0.7.0'});
+//     callback.onCall(1).returns({ version: '0.7.0'});
+
+//     await release.selectTaoInstance();
+//     await release.selectExtension();
+//     await release.selectReleasingBranch();
+//     await release.verifyReleasingBranch();
+
+//     t.equal(log.exit.callCount, 2, 'Exit message has been logged');
+//     t.ok(log.exit.calledWith(`Branch '${releasingBranch}' cannot be released because it's branch name does not match its own manifest version (0.7.0).`), 'Exit message has been logged with apropriate message');
+
+//     sandbox.restore();
+//     t.end();
+// });
+
+// test('Releasing branch is valid and is greather than release branch version', async (t) => {
+//     t.plan(4);
+
+//     sandbox.stub(gitClientInstance, 'fetch');
+//     sandbox.stub(gitClientInstance, 'getLocalBranches').returns(['remotes/origin/release-0.9.0']);
+//     sandbox.stub(log, 'doing');
+//     sandbox.stub(log, 'done');
+
+//     const callback = sandbox.stub(taoInstance, 'parseManifest');
+//     callback.onCall(0).returns({ version: '0.9.0'});
+//     callback.onCall(1).returns({ version: '0.8.0'});
+
+//     await release.selectTaoInstance();
+//     await release.selectExtension();
+//     await release.selectReleasingBranch();
+//     await release.verifyReleasingBranch();
+
+//     t.equal(log.doing.callCount, 2, 'Doing message has been logged');
+//     t.ok(log.doing.calledWith(`Branch ${releasingBranch} has valid manifest.`), 'Doing message has been logged with apropriate message');
+
+//     t.equal(log.done.callCount, 2, 'Done message has been logged');
+//     t.ok(log.done.calledWith(`Branch ${releasingBranch} is valid.`), 'Done message has been logged with apropriate message');
+
+//     sandbox.restore();
+//     t.end();
+// });
+
+// test('Releasing branch is valid but is less than release branch version', async (t) => {
+//     t.plan(4);
+
+//     sandbox.stub(gitClientInstance, 'fetch');
+//     sandbox.stub(gitClientInstance, 'getLocalBranches').returns([releasingBranch]);
+//     sandbox.stub(log, 'doing');
+//     sandbox.stub(log, 'exit');
+
+//     const callback = sandbox.stub(taoInstance, 'parseManifest');
+//     callback.onCall(0).returns({ version: '0.9.0'});
+//     callback.onCall(1).returns({ version: '0.10.0'});
+
+//     await release.selectTaoInstance();
+//     await release.selectExtension();
+//     await release.selectReleasingBranch();
+//     await release.verifyReleasingBranch();
+
+//     t.equal(log.doing.callCount, 2, 'Doing message has been logged');
+//     t.ok(log.doing.calledWith(`Branch ${releasingBranch} has valid manifest.`), 'Doing message has been logged with apropriate message');
+
+//     t.equal(log.exit.callCount, 1, 'Exit message has been logged');
+//     t.ok(log.exit.calledWith(`Branch '${releasingBranch}' cannot be released because its manifest version (0.9.0) is not greater than the manifest version of '${releaseBranch}' (0.10.0).`), 'Exit message has been logged with apropriate message');
+//     sandbox.restore();
+//     t.end();
+// });


### PR DESCRIPTION
**Related to task:** 
https://oat-sa.atlassian.net/browse/TAO-9130

**Description:**
- merges release branch into releasing branch
- ask user to resolve conflicts manually in case if any
- if user rejected resolving of conflicts, then clean up releasing branch

**How to test:**
`npm i`
`npm link`
`npm run test`
`taoRelease  createRelease`

**Unit tests:**
`node .\tests\unit\release\verifyReleasingBranch\test.js`

**Notes:**
- updated simple-git package