### PR TITLE
Fix/tao 9124/deprecate confirmRelease

### DIFF
--- a/src/release.js
+++ b/src/release.js
@@ -102,6 +102,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
 
         /**
          * Prompt user to confirm release
+         * @deprecated - only used in oldWayRelease for backward compatibility / user experience
          */
         async confirmRelease() {
             const { go } = await inquirer.prompt({


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-9124

Contrary to the ticket AC, we agreed internally (with @AntonTsymuk ) that the `confirmRelease` method should stay (to not break the old user experience), but be tagged as deprecated.

Nothing needs to be removed.