### PR TITLE
Fix/release notes failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-extension-release",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-extension-release",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Helps you to release TAO extensions",
   "main": "index.js",
   "scripts": {

--- a/src/release.js
+++ b/src/release.js
@@ -230,6 +230,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
                 log.info(data.pr.notes);
                 log.done();
             } else {
+                data.pr.notes = '-';
                 log.error('Unable to create the release notes. Continue.');
             }
         },

--- a/src/release.js
+++ b/src/release.js
@@ -230,7 +230,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
                 log.info(data.pr.notes);
                 log.done();
             } else {
-                data.pr.notes = '-';
+                data.pr.notes = '';
                 log.error('Unable to create the release notes. Continue.');
             }
         },

--- a/src/release.js
+++ b/src/release.js
@@ -230,7 +230,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
                 log.info(data.pr.notes);
                 log.done();
             } else {
-                log.exit('Unable to create the release notes');
+                log.error('Unable to create the release notes. Continue.');
             }
         },
 

--- a/tests/unit/release/extractReleaseNotes/test.js
+++ b/tests/unit/release/extractReleaseNotes/test.js
@@ -46,6 +46,7 @@ const gitClientInstance = {
 const gitClientFactory = sandbox.stub().callsFake(() => gitClientInstance);
 const log = {
     exit: () => { },
+    error: () => { },
     doing: () => { },
     done: () => { },
     info: () => { },
@@ -166,7 +167,7 @@ test('should log done message', async (t) => {
     t.end();
 });
 
-test('should log exit message if can not extract release notes', async (t) => {
+test('should log error message if can not extract release notes', async (t) => {
     t.plan(2);
 
     await release.selectTaoInstance();
@@ -175,12 +176,12 @@ test('should log exit message if can not extract release notes', async (t) => {
     await release.initialiseGithubClient();
     await release.createPullRequest();
 
-    sandbox.stub(log, 'exit');
+    sandbox.stub(log, 'error');
 
     await release.extractReleaseNotes();
 
-    t.equal(log.exit.callCount, 1, 'Exit has been logged');
-    t.ok(log.exit.calledWith('Unable to create the release notes'), 'Exit has been logged with apropriate message');
+    t.equal(log.error.callCount, 1, 'Error has been logged');
+    t.ok(log.error.calledWith('Unable to create the release notes. Continue.'), 'Error has been logged with apropriate message');
 
     sandbox.restore();
     t.end();


### PR DESCRIPTION
During working on the codebase I noticed that one thing that can block a release is if `extractReleaseNotes` fails. This can happen for example if no matching pull requests are found.

It's inconsistent because the tool can already recover from build errors or translation errors, but not release note errors.

I simply changed from `exit()` to `error()` in this scenario, and added an empty string as release notes.