### PR TITLE
Remove `update script` checkbox since we dont use any more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ tests/integration/work
 
 #IDE
 .vscode
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-extension-release",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Helps you to release TAO extensions",
   "main": "index.js",
   "scripts": {

--- a/src/github.js
+++ b/src/github.js
@@ -100,7 +100,6 @@ module.exports = function githubFactory(token, repository) {
             const checks = {
                 extension: [
                     `the manifest (versions ${version} and dependencies)`,
-                    `the update script (from ${fromVersion} to ${version})`,
                     'CSS and JavaScript bundles'
                 ],
                 package: [

--- a/tests/unit/github/test.js
+++ b/tests/unit/github/test.js
@@ -123,7 +123,6 @@ test('the method getReleasePRComment', t => {
     t.equal(ghclient.getReleasePRComment(), `Please verify the following points :
 
 - [ ] the manifest (versions ?.?.? and dependencies),
-- [ ] the update script (from ?.?.? to ?.?.?),
 - [ ] CSS and JavaScript bundles`);
 
     ghclient = github(token, 'oat-sa/tao-core');
@@ -131,7 +130,6 @@ test('the method getReleasePRComment', t => {
     t.equal(ghclient.getReleasePRComment('18.7.3', '18.6.0'), `Please verify the following points :
 
 - [ ] the manifest (versions 18.7.3 and dependencies),
-- [ ] the update script (from 18.6.0 to 18.7.3),
 - [ ] CSS and JavaScript bundles,
 - [ ] Increase TAO-VERSION in \`manifest.php\``);
 


### PR DESCRIPTION
**Description**

Since we will not use any longer more `updater script`, remove from our extension release tool

![imagen](https://user-images.githubusercontent.com/34692207/89026909-ca566180-d329-11ea-8e76-d18f355c1629.png)
