### PR TITLE
fix: coerce non-semver versions

### DIFF
--- a/src/conventionalCommits.js
+++ b/src/conventionalCommits.js
@@ -61,7 +61,7 @@ module.exports = {
      * @returns {Promise}
      */
     async getNextVersion(lastTag) {
-        let lastVersionObject = semverValid(lastTag) ? semverParse(lastTag) : semverCoerce(lastTag);
+        const lastVersionObject = semverValid(lastTag) === null ? semverParse(lastTag) : semverCoerce(lastTag);
         if (!lastVersionObject) {
             throw new Error('Unable to retrieve last version from tags or the last tag is not semver compliant');
         }

--- a/src/conventionalCommits.js
+++ b/src/conventionalCommits.js
@@ -27,8 +27,10 @@
 const conventionalChangelogCore = require('conventional-changelog-core');
 const conventionalPresetConfig = require('@oat-sa/conventional-changelog-tao');
 const conventionalRecommendedBump = require('conventional-recommended-bump');
-const semverParse = require('semver/functions/parse');
 const semverInc = require('semver/functions/inc');
+const semverValid = require('semver/functions/valid');
+const semverCoerce = require('semver/functions/coerce');
+const semverParse = require('semver/functions/coerce');
 
 module.exports = {
     /**
@@ -59,9 +61,9 @@ module.exports = {
      * @returns {Promise}
      */
     async getNextVersion(lastTag) {
-        const lastVersionObject = semverParse(lastTag);
+        let lastVersionObject = semverValid(lastTag) ? semverParse(lastTag) : semverCoerce(lastTag);
         if (!lastVersionObject) {
-            throw new Error('Unable to retrieve last version from tags');
+            throw new Error('Unable to retrieve last version from tags or the last tag is not semver compliant');
         }
 
         return new Promise((resolve, reject) => {

--- a/src/release.js
+++ b/src/release.js
@@ -69,7 +69,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
         throw new Error(`No implementation found for the type '${subjectType}'`);
     }
 
-    if ( releaseVersion && semverValid(releaseVersion) === null) {
+    if (releaseVersion && semverValid(releaseVersion) === null) {
         throw new Error(`'${releaseVersion}' is not a valid semver version.`);
     }
 

--- a/src/release.js
+++ b/src/release.js
@@ -31,6 +31,7 @@ const github = require('./github.js');
 const gitClientFactory = require('./git.js');
 const log = require('./log.js');
 const conventionalCommits = require('./conventionalCommits.js');
+const semverValid = require('semver/functions/valid');
 
 const adaptees = {
     extension : require('./release/extensionApi.js'),
@@ -67,6 +68,11 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
     if (!adaptees[subjectType]) {
         throw new Error(`No implementation found for the type '${subjectType}'`);
     }
+
+    if ( releaseVersion && semverValid(releaseVersion) === null) {
+        throw new Error(`'${releaseVersion}' is not a valid semver version.`);
+    }
+
     /**
      * @typedef adaptee - an instance of a supplemental API with methods specific to the release subject type
      */


### PR DESCRIPTION
**What's wrong:**

Some tag versions doesn't comply with semver, like `12.3.4.5`. The release tool will just fail when trying to parse such version. 

**What's expected:** 

The release tool try to coerce the version to the semver root. For example  `12.3.4.5` will be coerced to `12.3.4` so the next patch version will be  `12.3.5`

How to test:
 - run the unit tests
 - try it on extension-tao-foobar (the last tag is `v7.4.13.1`)