### PR TITLE
Fix/GitHub token regex

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -32,8 +32,8 @@ const validate = {
      * @returns {validate} chains
      * @throws {TypeError} when invalid
      */
-    githubToken(token, errorMsg = 'The Github token is missing or not well formatted, we expect a long hexa string.'){
-        if(typeof token !== 'string' || !/[0-9A-Fa-f]{6,}/g.test(token)){
+    githubToken(token, errorMsg = 'The Github token is missing or not well formatted.') {
+        if (typeof token !== 'string' || !/^(ghp_)?[0-9A-Za-z]{6,}/g.test(token)) {
             throw new TypeError(errorMsg);
         }
         return this;

--- a/tests/unit/validate/test.js
+++ b/tests/unit/validate/test.js
@@ -32,7 +32,7 @@ test('the module api', t => {
 });
 
 test('the githubToken method', t => {
-    t.plan(12);
+    t.plan(14);
 
     t.ok(typeof validate.githubToken === 'function', 'The module expose a githubToken method');
 
@@ -41,10 +41,11 @@ test('the githubToken method', t => {
     t.throws(() => validate.githubToken('12'), TypeError);
     t.throws(() => validate.githubToken(12), TypeError);
     t.throws(() => validate.githubToken('AE'), TypeError);
+    t.throws(() => validate.githubToken('gho_12345abc'), TypeError);
     try {
         validate.githubToken('foo');
     } catch(err){
-        t.equal(err.message, 'The Github token is missing or not well formatted, we expect a long hexa string.');
+        t.equal(err.message, 'The Github token is missing or not well formatted.');
     }
     try {
         validate.githubToken('foo', 'Custom Message');
@@ -55,6 +56,7 @@ test('the githubToken method', t => {
     t.doesNotThrow( () => validate.githubToken('01AF9E99BFE0'),'Upper case small token');
     t.doesNotThrow( () => validate.githubToken('01af9e99fe012a01'), 'Lower case small token');
     t.doesNotThrow( () => validate.githubToken('23acf5dd2087369942acef7a30b4c5e070ee0b79'), 'Real token');
+    t.doesNotThrow( () => validate.githubToken('ghp_XhtlFn124mUjukG6lzGgJvX6AhC5UZ0PnT5Y'), 'Real token, prefixed format');
 
     t.deepEqual(validate.githubToken('01af9e99fe012a01'), validate, 'The method chains');
 


### PR DESCRIPTION
Update token regex to support old (40-char hexadecimal) and new (40-char alphanumeric with `ghp_` prefix) github access tokens. This needs doing otherwise the release tool becomes unable to release for anyone who upgraded their token without saving the old one.

Read about new tokens [here](https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/).

For a real life test, generate yourself a new token on https://github.com/settings/tokens, set it in `~/.tao-extension-release`, and start a release. (Back up your old token just in case!)

Also run `npm run test:unit`