### PR TITLE
feat: include the git remote prune origin step into the command

### DIFF
--- a/src/commands/extensionRelease.js
+++ b/src/commands/extensionRelease.js
@@ -65,6 +65,7 @@ async function releaseExtension() {
         await release.signTags();
         await release.verifyBranches();
         await release.extractVersion();
+        await release.pruneRemoteOrigin();
         await release.doesTagExists();
         await release.doesReleasingBranchExists();
         await release.isReleaseRequired();

--- a/src/commands/npmRelease.js
+++ b/src/commands/npmRelease.js
@@ -59,6 +59,7 @@ async function npmRelease() {
         await release.signTags();
         await release.verifyBranches();
         await release.extractVersion();
+        await release.pruneRemoteOrigin();
         await release.doesTagExists();
         await release.doesReleasingBranchExists();
         await release.isReleaseRequired();

--- a/src/commands/repoRelease.js
+++ b/src/commands/repoRelease.js
@@ -59,6 +59,7 @@ async function repoRelease() {
         await release.signTags();
         await release.verifyBranches();
         await release.extractVersion();
+        await release.pruneRemoteOrigin();
         await release.doesTagExists();
         await release.doesReleasingBranchExists();
         await release.isReleaseRequired();

--- a/src/git.js
+++ b/src/git.js
@@ -168,6 +168,16 @@ module.exports = function gitFactory(repository = '', origin = 'origin') {
         },
 
         /**
+         * Prune the remote origin, clearing the branches that no longer exist
+         *
+         * @param {String} origin - name of the remote
+         * @returns {Promise<Boolean>}
+         */
+        pruneRemote(origin) {
+            return git(repository).remote(['prune', origin]);
+        },
+
+        /**
          * Does the given tag exists
          * @param {String} tagName
          * @returns {Promise<Boolean>}

--- a/src/release.js
+++ b/src/release.js
@@ -272,6 +272,17 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
         },
 
         /**
+         * Prune no longer existing branches in the remote origin
+         */
+        async pruneRemoteOrigin() {
+            log.doing('Pruning the remote branches');
+
+            await gitClient.pruneRemote(origin);
+
+            log.done(`Remote branches pruned`);
+        },
+
+        /**
          * Check if release tag exists
          */
         async doesTagExists() {

--- a/src/release.js
+++ b/src/release.js
@@ -279,7 +279,7 @@ module.exports = function taoExtensionReleaseFactory(params = {}) {
 
             await gitClient.pruneRemote(origin);
 
-            log.done(`Remote branches pruned`);
+            log.done('Remote branches pruned');
         },
 
         /**


### PR DESCRIPTION
Recently we've had a bug when trying to release a new version.

The problem was that when @SergiiTao was instructing me on how to make a release, the cached index of remote branches still pointed to a release branch we had deleted a few minutes ago.

Since this is an automated tool, pruning the remote branches shouldn't be considered too big an effort and it might help avoiding similar problems in the future