### PR TITLE
feat: attaching a label with release PR

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -69,7 +69,28 @@ export default function githubFactory(token, repository) {
                 });
             });
         },
+        /**
+         * Create the release pull request
+         * @param {String} releasingBranch - the temp branch that contains the commits to release
+         * @param {String} releaseBranch - the base branch
+         * @param {String} version - the version of the release
+         * @param {String} fromVersion - the last version
+         * @returns {Promise<Object>} - resolves with the pull request data
+         */
 
+        addLabel(repo,id,label, cbs) {
+            const ghpr = client.issue(repo,id,'');
+            return new Promise((resolve, reject) => {
+                ghpr.addLabels({
+                    labels: label
+                }, (err, data) => {
+                    if (err) {
+                        return reject(err);
+                    }
+                    return resolve(data);
+                });
+            });
+        },
         /**
          * Create the release pull request
          * @param {String} releasingBranch - the temp branch that contains the commits to release

--- a/src/github.js
+++ b/src/github.js
@@ -78,8 +78,8 @@ export default function githubFactory(token, repository) {
          * @returns {Promise<Object>} - resolves with the pull request data
          */
 
-        addLabel(repo,id,label, cbs) {
-            const ghpr = client.issue(repo,id,'');
+        addLabel(repo,number,label) {
+            const ghpr = client.issue(repo,number);
             return new Promise((resolve, reject) => {
                 ghpr.addLabels({
                     labels: label
@@ -91,6 +91,7 @@ export default function githubFactory(token, repository) {
                 });
             });
         },
+       
         /**
          * Create the release pull request
          * @param {String} releasingBranch - the temp branch that contains the commits to release

--- a/src/release.js
+++ b/src/release.js
@@ -243,9 +243,12 @@ export default function taoExtensionReleaseFactory(params = {}) {
                     number: pullRequest.number,
                     id: pullRequest.id
                 };
-
+                                
                 log.info(`${data.pr.url} created`);
                 log.done();
+                let labels = ["releases"];
+
+                await githubClient.addLabel(`${pullRequest.head.repo.owner.login}/${pullRequest.head.repo.name}`,pullRequest.number,labels,pullRequest)
             } else {
                 log.exit('Unable to create the release pull request');
             }

--- a/src/release.js
+++ b/src/release.js
@@ -243,12 +243,13 @@ export default function taoExtensionReleaseFactory(params = {}) {
                     number: pullRequest.number,
                     id: pullRequest.id
                 };
-                                
+
                 log.info(`${data.pr.url} created`);
                 log.done();
-                let labels = ["releases"];
-
-                await githubClient.addLabel(`${pullRequest.head.repo.owner.login}/${pullRequest.head.repo.name}`,pullRequest.number,labels,pullRequest)
+                const labels = ["releases"];
+                await githubClient.addLabel(`${pullRequest.head.repo.owner.login}/${pullRequest.head.repo.name}`,pullRequest.number,labels);
+                log.info('label attached');
+                log.done();
             } else {
                 log.exit('Unable to create the release pull request');
             }


### PR DESCRIPTION
secure frame will audit all pull request has been approved by an independent person or it has a particular emergency label attached with it. 