### PR TITLE
Feature/tr 5972/monorepo release custom versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ This command does:
 
 At then end, you will be prompted to trigger the execution of `npm publish`. The Github release is already finished at this stage. If the publish step fails, you can try again manually, or ask someone with the necessary privileges to perform the publishing.
 
+
+### NPM packages in monorepo
+
+If the repository is a lerna-managed monorepo, and contains npm packages, please use the command `npmReleaseMonorepo`. This command _must_ be run in the root directory of the monorepo.
+
+```sh
+cd path/to/my/package/repo
+taoRelease npmReleaseMonorepo
+```
+
+TODO
+
 ### Tag based repositories
 
 For any other repository that doesn't need any special build but only tagging and merging, like PHP libraries, please use the command `repoRelease`. This command _must_ be run in the root directory of the repository.

--- a/README.md
+++ b/README.md
@@ -53,14 +53,22 @@ At then end, you will be prompted to trigger the execution of `npm publish`. The
 
 ### NPM packages in monorepo
 
-If the repository is a lerna-managed monorepo, and contains npm packages, please use the command `npmReleaseMonorepo`. This command _must_ be run in the root directory of the monorepo.
+If the repository is a _lerna_-managed monorepo, and contains npm packages, please use the command `npmReleaseMonorepo`. This command _must_ be run in the root directory of the monorepo. Monorepo must be have `lerna` installed at the root, because release tool will use its CLI to get infromation about packages.
 
 ```sh
 cd path/to/my/package/repo
 taoRelease npmReleaseMonorepo
 ```
 
-TODO
+This command does:
+
+- compute the next version from commits
+    - for root, and for each package. Based on commits that touch files in this package.
+- update the package.json and package-lock.json
+   - for root, and for each package
+- create a tag and a release
+- publish the packages to npm
+    - the Github release is already finished at this stage. If the publish step fails, you can try again manually, or ask someone with the necessary privileges to perform the publishing.
 
 ### Tag based repositories
 
@@ -103,6 +111,14 @@ Commandline arguments to give you more control over the parameters of the releas
 | `--extension-to-release <extension>` | extension name (e.g. taoFoobar)                                                                    | (none - prompted) |
 | `--update-translations`              | run translation update without prompting. Translations update is only available in interative mode. |                   |
 | `--www-user <user>`                  | the system user used to launch PHP commands                                                        | `www-data`        |
+
+### npmReleaseMonorepo extra options
+
+| option                     | description                                                                                        | default           |
+| -------------------------- | -------------------------------------------------------------------------------------------------- | ----------------- |
+| `--release-tag`            | tag to be used for the release, if it's different from root package.json version                   |                   |
+| `--conventional-bump-type` | one of: `none`,`patch`, `minor`, `major`. If not specified, will be calculated from conventional commits on each package. If `none`, will not change package versions. |                   |
+| `--no-publish`         | do not publish packages to npm. Publishing is done as the last step. For no-interactive node.      |                   |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Commandline arguments to give you more control over the parameters of the releas
 | -------------------------- | -------------------------------------------------------------------------------------------------- | ----------------- |
 | `--release-tag`            | tag to be used for the release, if it's different from root package.json version                   |                   |
 | `--conventional-bump-type` | one of: `none`,`patch`, `minor`, `major`. If not specified, will be calculated from conventional commits on each package. If `none`, will not change package versions. |                   |
-| `--no-publish`         | do not publish packages to npm. Publishing is done as the last step. For no-interactive node.      |                   |
+| `--no-publish`         | do not publish packages to npm. Publishing is done as the last step. For no-interactive mode.      |                   |
 
 ## Development
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2023 Open Assessment Technologies SA;
+ * Copyright (c) 2017-2024 Open Assessment Technologies SA;
  */
 
 /**
@@ -48,7 +48,7 @@ program
     .command('npmRelease', 'release and publish an npm package', {
         executableFile: './src/commands/npmRelease'
     })
-    .command('npmReleaseMonorepo', 'release and publish npm packages from lerna monorepo', {
+    .command('npmReleaseMonorepo', 'release and publish npm packages from monorepo', {
         executableFile: './src/commands/npmReleaseMonorepo'
     })
     .command('repoRelease', 'release any repository', {

--- a/index.js
+++ b/index.js
@@ -48,6 +48,9 @@ program
     .command('npmRelease', 'release and publish an npm package', {
         executableFile: './src/commands/npmRelease'
     })
+    .command('npmReleaseMonorepo', 'release and publish npm packages from lerna monorepo', {
+        executableFile: './src/commands/npmReleaseMonorepo'
+    })
     .command('repoRelease', 'release any repository', {
         executableFile: './src/commands/repoRelease'
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "semver": "^7.3.4",
         "simple-git": "^3.17.0",
         "update-notifier": "^6.0.2",
+        "write-json-file": "^3.2.0",
         "write-pkg": "^4.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "semver": "^7.3.4",
     "simple-git": "^3.17.0",
     "update-notifier": "^6.0.2",
-    "write-pkg": "^4.0.0"
+    "write-pkg": "^4.0.0",
+    "write-json-file": "^3.2.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/src/commands/cliOptions.js
+++ b/src/commands/cliOptions.js
@@ -28,12 +28,12 @@ export default {
     branchPrefix: ['--branch-prefix <prefix>', 'the prefix of the branch created for releasing', 'release'],
     origin: ['--origin <remotename>', 'the name of the remote repo', 'origin'],
     releaseBranch: ['--release-branch <branch>', 'the target branch for the release PR', 'master'],
-    releaseTag: ['--release-tag', 'the tag to create for the release'],
+    releaseTag: ['--release-tag <tag>', 'the tag to create for the release'],
     wwwUser: ['--www-user <user>', 'the user who runs php commands', 'www-data'],
     updateTranslations: ['--update-translations', 'indicates if we need to update translations. Only available in interactive mode.'],
     noInteractive: ['--no-interactive', 'non interactive mode, always off on non TTY env'],
     noWrite: ['--no-write', 'turns off writting data like the config'],
-    conventionalBumpType: ['--conventional-bump-type', 'none|patch|minor|major, if all packages should be bumped the same way. If not specified, then from conventional commits for the package'],
+    conventionalBumpType: ['--conventional-bump-type <bump>', 'none|patch|minor|major, if all packages should be bumped the same way. If not specified, then from conventional commits for the package'],
     noPublish: ['--no-publish', 'do not publish packages to npm'],
 
     // options which fall back to user prompts if undefined

--- a/src/commands/cliOptions.js
+++ b/src/commands/cliOptions.js
@@ -28,10 +28,13 @@ export default {
     branchPrefix: ['--branch-prefix <prefix>', 'the prefix of the branch created for releasing', 'release'],
     origin: ['--origin <remotename>', 'the name of the remote repo', 'origin'],
     releaseBranch: ['--release-branch <branch>', 'the target branch for the release PR', 'master'],
+    releaseTag: ['--release-tag', 'the tag to create for the release'],
     wwwUser: ['--www-user <user>', 'the user who runs php commands', 'www-data'],
     updateTranslations: ['--update-translations', 'indicates if we need to update translations. Only available in interactive mode.'],
     noInteractive: ['--no-interactive', 'non interactive mode, always off on non TTY env'],
     noWrite: ['--no-write', 'turns off writting data like the config'],
+    conventionalBumpType: ['--conventional-bump-type', 'none|patch|minor|major, if all packages should be bumped the same way. If not specified, then from conventional commits for the package'],
+    noPublish: ['--no-publish', 'do not publish packages to npm'],
 
     // options which fall back to user prompts if undefined
     pathToTao: ['--path-to-tao <path>', 'path to local TAO instance'],

--- a/src/commands/npmRelease.js
+++ b/src/commands/npmRelease.js
@@ -45,8 +45,6 @@ if (program.debug) {
     log.info(program.opts());
 }
 
-log.setExitCode(1);  //if we exit early, we assume it's an error
-
 const release = taoExtensionReleaseFactory({ ...program.opts(), subjectType: 'package' });
 
 async function npmRelease() {
@@ -79,7 +77,6 @@ async function npmRelease() {
         await release.removeReleasingBranch();
         await release.publish();
 
-        log.setExitCode(0);
         log.done('Good job!').exit();
     } catch (error) {
         log.error(error).exit();

--- a/src/commands/npmRelease.js
+++ b/src/commands/npmRelease.js
@@ -45,6 +45,8 @@ if (program.debug) {
     log.info(program.opts());
 }
 
+log.setExitCode(1);  //if we exit early, we assume it's an error
+
 const release = taoExtensionReleaseFactory({ ...program.opts(), subjectType: 'package' });
 
 async function npmRelease() {
@@ -77,6 +79,7 @@ async function npmRelease() {
         await release.removeReleasingBranch();
         await release.publish();
 
+        log.setExitCode(0);
         log.done('Good job!').exit();
     } catch (error) {
         log.error(error).exit();

--- a/src/commands/npmReleaseMonorepo.js
+++ b/src/commands/npmReleaseMonorepo.js
@@ -1,0 +1,90 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020-2021 Open Assessment Technologies SA;
+ */
+
+import log from '../log.js';
+import commander from 'commander';
+import cliOptions from './cliOptions.js';
+import taoExtensionReleaseFactory from '../release.js';
+
+const program = new commander.Command();
+
+program
+    .name('taoRelease npmReleaseMonorepo')
+    .usage('[options]')
+    .option(...cliOptions.debug)
+    .option(...cliOptions.releaseVersion)
+
+    // options with defaults
+    .option(...cliOptions.baseBranch)
+    .option(...cliOptions.branchPrefix)
+    .option(...cliOptions.origin)
+    .option(...cliOptions.releaseBranch)
+    .option(...cliOptions.noInteractive)
+    .option(...cliOptions.noWrite)
+
+    // options which fall back to user prompts if undefined
+    .option(...cliOptions.releaseComment)
+    .parse(process.argv);
+
+if (program.debug) {
+    log.info(program.opts());
+}
+
+const release = taoExtensionReleaseFactory({ ...program.opts(), subjectType: 'package' });
+
+async function npmRelease() {
+    try {
+        log.title('Release npm packages in monorepo');
+
+        //somewhere confirm that it's a lerna monorepo, lerna is installed [npx lerna]
+        //check that command is called from repo root
+        //
+        await release.loadConfig();
+        await release.selectTarget();
+        await release.initialiseGithubClient();
+        await release.verifyCredentials();
+        await release.writeConfig();
+        await release.initialiseGitClient();
+        await release.verifyLocalChanges();
+        await release.signTags();
+        await release.verifyBranches();
+        await release.extractVersion();
+        await release.extractLernaMonorepoVersion();
+        await release.pruneRemoteOrigin();
+        await release.doesTagExists();
+        await release.doesReleasingBranchExists();
+        await release.isReleaseRequired();
+        await release.confirmLernaMonorepoRelease();
+        await release.createReleasingBranch();
+        await release.updateLernaMonorepoVersions();
+        await release.createPullRequest();
+        await release.extractReleaseNotes();
+        await release.mergePullRequest();
+        await release.createReleaseTag();
+        await release.createGithubRelease();
+        await release.mergeBack();
+        await release.removeReleasingBranch();
+        await release.publishLernaMonorepo();
+
+        log.done('Good job!').exit();
+    } catch (error) {
+        log.error(error).exit();
+    }
+}
+
+npmRelease();

--- a/src/commands/npmReleaseMonorepo.js
+++ b/src/commands/npmReleaseMonorepo.js
@@ -45,6 +45,8 @@ if (program.debug) {
     log.info(program.opts());
 }
 
+log.setExitCode(1);  //if we exit early, we assume it's an error
+
 const release = taoExtensionReleaseFactory({ ...program.opts(), subjectType: 'package' });
 
 async function npmRelease() {
@@ -81,6 +83,7 @@ async function npmRelease() {
         await release.removeReleasingBranch();
         await release.publishLernaMonorepo();
 
+        log.setExitCode(0);
         log.done('Good job!').exit();
     } catch (error) {
         log.error(error).exit();

--- a/src/commands/npmReleaseMonorepo.js
+++ b/src/commands/npmReleaseMonorepo.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020-2021 Open Assessment Technologies SA;
+ * Copyright (c) 2024 Open Assessment Technologies SA;
  */
 
 import log from '../log.js';
@@ -36,6 +36,9 @@ program
     .option(...cliOptions.releaseBranch)
     .option(...cliOptions.noInteractive)
     .option(...cliOptions.noWrite)
+    .option(...cliOptions.releaseTag)
+    .option(...cliOptions.conventionalBumpType)
+    .option(...cliOptions.noPublish)
 
     // options which fall back to user prompts if undefined
     .option(...cliOptions.releaseComment)
@@ -53,9 +56,6 @@ async function npmRelease() {
     try {
         log.title('Release npm packages in monorepo');
 
-        //somewhere confirm that it's a lerna monorepo, lerna is installed [npx lerna]
-        //check that command is called from repo root
-        //
         await release.loadConfig();
         await release.selectTarget();
         await release.initialiseGithubClient();
@@ -66,14 +66,14 @@ async function npmRelease() {
         await release.signTags();
         await release.verifyBranches();
         await release.extractVersion();
-        await release.extractLernaMonorepoVersion();
+        await release.extractMonorepoVersions();
         await release.pruneRemoteOrigin();
         await release.doesTagExists();
         await release.doesReleasingBranchExists();
         await release.isReleaseRequired();
-        await release.confirmLernaMonorepoRelease();
+        await release.confirmRelease();
         await release.createReleasingBranch();
-        await release.updateLernaMonorepoVersions();
+        await release.updateVersion();
         await release.createPullRequest();
         await release.extractReleaseNotes();
         await release.mergePullRequest();
@@ -81,7 +81,7 @@ async function npmRelease() {
         await release.createGithubRelease();
         await release.mergeBack();
         await release.removeReleasingBranch();
-        await release.publishLernaMonorepo();
+        await release.publish();
 
         log.setExitCode(0);
         log.done('Good job!').exit();

--- a/src/conventionalCommits.js
+++ b/src/conventionalCommits.js
@@ -73,7 +73,7 @@ export default {
     async getVersionFromTag(lastTag) {
         const lastVersionObject = semverCoerce(lastTag);
         if (!lastVersionObject) {
-            throw new Error('Unable to retrieve last version from tags or the last tag is not semver compliant');
+            throw new Error(`Unable to retrieve last version from tags or the last tag "${lastTag}" is not semver compliant`);
         }
         return lastVersionObject.version;
     },
@@ -88,7 +88,7 @@ export default {
     async getNextVersion(lastVersion, pathInMonorepo = null) {
         const lastVersionObject = semverCoerce(lastVersion);
         if (!lastVersionObject) {
-            throw new Error('Last version is not semver compliant');
+            throw new Error(`Last version "${lastVersion}" is not semver compliant`);
         }
 
         return new Promise((resolve, reject) => {

--- a/src/conventionalCommits.js
+++ b/src/conventionalCommits.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 Open Assessment Technologies SA;
+ * Copyright (c) 2020-2024 Open Assessment Technologies SA;
  */
 
 /**
@@ -29,6 +29,17 @@ import conventionalPresetConfig from '@oat-sa/conventional-changelog-tao';
 import conventionalRecommendedBump from 'conventional-recommended-bump';
 import semverInc from 'semver/functions/inc.js';
 import semverCoerce from 'semver/functions/coerce.js';
+
+
+/**
+ * `semver` release types, can be used to specify version increment
+ */
+export const conventionalBumpTypes = Object.freeze({
+    none: 'none', //do nothing
+    patch: 'patch', //1.2.3 -> 1.2.4
+    minor: 'minor', //1.2.3 -> 1.3.0
+    major: 'major' //1.2.3 -> 2.0.0
+});
 
 export default {
     /**
@@ -52,17 +63,32 @@ export default {
                 .on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
         });
     },
+
     /**
-     * Get next recommended version
-     *
+     * Extract version from semver-like release tag
+     * (v1.2.3 -> 1.2.3)
      * @param {String} lastTag
-     * @param {String?} pathInMonorepo
-     * @returns {Promise}
+     * @returns {String}
      */
-    async getNextVersion(lastTag, pathInMonorepo = null) {
+    async getVersionFromTag(lastTag) {
         const lastVersionObject = semverCoerce(lastTag);
         if (!lastVersionObject) {
             throw new Error('Unable to retrieve last version from tags or the last tag is not semver compliant');
+        }
+        return lastVersionObject.version;
+    },
+
+    /**
+     * Get next recommended version
+     *
+     * @param {String} lastVersion
+     * @param {String?} pathInMonorepo
+     * @returns {Promise}
+     */
+    async getNextVersion(lastVersion, pathInMonorepo = null) {
+        const lastVersionObject = semverCoerce(lastVersion);
+        if (!lastVersionObject) {
+            throw new Error('Last version is not semver compliant');
         }
 
         return new Promise((resolve, reject) => {
@@ -79,15 +105,21 @@ export default {
                         return reject(err);
                     }
 
-                    const lastVersion = lastVersionObject.version;
-
                     //carefull inc mutate lastVersionObject
                     const version = semverInc(lastVersionObject, recommendation.releaseType);
-                    resolve({ lastVersion, version, recommendation });
+                    resolve({ version, recommendation });
                 });
         });
     },
 
+
+    /**
+     * Get next version, incremented by specified release-type
+     *
+     * @param {String} lastVersion
+     * @param {String} releaseType
+     * @returns {String}
+     */
     incrementVersion(lastVersion, releaseType) {
         const lastVersionObject = semverCoerce(lastVersion);
         if (!lastVersionObject) {

--- a/src/conventionalCommits.js
+++ b/src/conventionalCommits.js
@@ -56,9 +56,10 @@ export default {
      * Get next recommended version
      *
      * @param {String} lastTag
+     * @param {String?} pathInMonorepo
      * @returns {Promise}
      */
-    async getNextVersion(lastTag) {
+    async getNextVersion(lastTag, pathInMonorepo = null) {
         const lastVersionObject = semverCoerce(lastTag);
         if (!lastVersionObject) {
             throw new Error('Unable to retrieve last version from tags or the last tag is not semver compliant');
@@ -69,7 +70,8 @@ export default {
                 {
                     preset: {
                         name: '@oat-sa/tao'
-                    }
+                    },
+                    path: pathInMonorepo
                 },
                 {},
                 (err, recommendation) => {
@@ -84,5 +86,13 @@ export default {
                     resolve({ lastVersion, version, recommendation });
                 });
         });
+    },
+
+    incrementVersion(lastVersion, releaseType) {
+        const lastVersionObject = semverCoerce(lastVersion);
+        if (!lastVersionObject) {
+            throw new Error(`Can not increment version: ${lastVersion} is not semver compliant`);
+        }
+        return semverInc(lastVersionObject, releaseType);
     }
 };

--- a/src/conventionalCommits.js
+++ b/src/conventionalCommits.js
@@ -70,7 +70,7 @@ export default {
      * @param {String} lastTag
      * @returns {String}
      */
-    async getVersionFromTag(lastTag) {
+    getVersionFromTag(lastTag) {
         const lastVersionObject = semverCoerce(lastTag);
         if (!lastVersionObject) {
             throw new Error(`Unable to retrieve last version from tags or the last tag "${lastTag}" is not semver compliant`);

--- a/src/log.js
+++ b/src/log.js
@@ -63,6 +63,10 @@ export default {
     },
     exit(msg) {
         console.log(msg || 'Good bye');
-        process.exit();
+        process.exit(this.exitCode);
+    },
+    setExitCode(exitCode) {
+        this.exitCode = exitCode;
+        return this;
     }
 };

--- a/src/log.js
+++ b/src/log.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2020 Open Assessment Technologies SA;
+ * Copyright (c) 2017-2024 Open Assessment Technologies SA;
  */
 
 /*eslint no-console: "off"*/

--- a/src/npmPackage.js
+++ b/src/npmPackage.js
@@ -57,7 +57,7 @@ export default function npmPackageFactory(rootDir = '', quiet = true) {
     const runCommand = (npmNpx, command, spawnOptions = {}) => {
         return new Promise((resolve, reject) => {
             if (typeof command !== 'string') {
-                return reject(new TypeError(`Invalid argument type: ${typeof command} for ${npmNpx} (should be string)`));
+                return reject(new TypeError(`Invalid argument type: ${typeof command} for ${npmNpx}Command (should be string)`));
             }
             const opts = { ...getOptions(), ...spawnOptions };
             log.info(`${npmNpx} ${command}`, opts);

--- a/src/npmPackage.js
+++ b/src/npmPackage.js
@@ -51,13 +51,15 @@ export default function npmPackageFactory(rootDir = '', quiet = true) {
 
     /**
      * Run any npm/npx command and wrap result in a Promise
-     * @param {String} command
+     * @param {String} npmNpx - `npm` or `npx`
+     * @param {String} command - command which `npm` or `npx` should invoke
+     * @param {Object?} spawnOptions - options for `crossSpawn`
      * @returns {Promise} - resolves if command ran without errors, with data returned by command if any
      */
     const runCommand = (npmNpx, command, spawnOptions = {}) => {
         return new Promise((resolve, reject) => {
-            if (typeof command !== 'string') {
-                return reject(new TypeError(`Invalid argument type: ${typeof command} for ${npmNpx}Command (should be string)`));
+            if (typeof npmNpx !== 'string' || typeof command !== 'string') {
+                return reject(new TypeError('Invalid argument type: npm/npx command: "npmNpx" and "command" arguments should be string'));
             }
             const opts = { ...getOptions(), ...spawnOptions };
             log.info(`${npmNpx} ${command}`, opts);
@@ -161,6 +163,7 @@ export default function npmPackageFactory(rootDir = '', quiet = true) {
         /**
          * Run any npx command and wrap result in a Promise
          * @param {String} command
+         * @param {Object?} spawnOptions
          * @returns {Promise<*>} - resolves if command ran without errors, with data returned by command if any
          */
         npxCommand(command, spawnOptions = {}) {

--- a/src/npmPackage.js
+++ b/src/npmPackage.js
@@ -268,7 +268,7 @@ export default function npmPackageFactory(rootDir = '', quiet = true) {
           * @return {Promise<Object[]} - `[{ packageName: string, packagePath: string, lastVersion: string, dependencies: string[] }]`
           */
         async lernaGetPackagesList() {
-            const packageListStr = await this.npxCommand('lerna list --json', { stdio: 'pipe' });
+            const packageListStr = await this.npxCommand('lerna list --all --json', { stdio: 'pipe' });
 
             const packageListJson = JSON.parse(packageListStr);
             const packagesInfo = packageListJson.map(packageInfo => ({
@@ -277,7 +277,7 @@ export default function npmPackageFactory(rootDir = '', quiet = true) {
                 lastVersion: packageInfo.version
             }));
 
-            const packageGraphStr = await this.npxCommand('lerna list --graph', { stdio: 'pipe' });
+            const packageGraphStr = await this.npxCommand('lerna list --all --graph', { stdio: 'pipe' });
 
             const packageGraphJson = JSON.parse(packageGraphStr);
             for (const packageInfo of packagesInfo) {

--- a/src/release.js
+++ b/src/release.js
@@ -245,7 +245,7 @@ export default function taoExtensionReleaseFactory(params = {}) {
                 fullReleaseComment += [
                     '\n```',
                     data.monorepoPackages
-                        .map(i => `"${i.packageName}": ${i.lastVersion}`)
+                        .map(i => `"${i.packageName}": ${i.version}`)
                         .join('\n'),
                     '```'
                 ].join('\n');

--- a/src/release.js
+++ b/src/release.js
@@ -668,7 +668,7 @@ export default function taoExtensionReleaseFactory(params = {}) {
 
             let recommendation;
             let version;
-            if (params.conventionalBumpType) {
+            if (params.conventionalBumpType && params.conventionalBumpType !== conventionalBumpTypes.none) {
                 version = conventionalCommits.incrementVersion(lastVersion, params.conventionalBumpType);
                 recommendation = { reason: `fixed bump to "${params.conventionalBumpType}"` };
             } else {
@@ -747,16 +747,16 @@ export default function taoExtensionReleaseFactory(params = {}) {
 
             //calculate next version for each package (own changes)
             for (const packageInfo of packagesInfo) {
-                if (params.conventionalBumpType) {
-                    //same fixed bump for all packages
-                    const version = conventionalCommits.incrementVersion(packageInfo.lastVersion, params.conventionalBumpType);
-                    packageInfo.recommendation = { reason: `fixed bump to "${params.conventionalBumpType}"` };
-                    packageInfo.version = version;
-                } else if (params.conventionalBumpType === conventionalBumpTypes.none) {
+                if (params.conventionalBumpType === conventionalBumpTypes.none) {
                     //update versions manually once PR is opened
                     packageInfo.noChanges = true;
                     packageInfo.recommendation = { reason: 'no bump' };
                     packageInfo.version = packageInfo.lastVersion;
+                } else if (params.conventionalBumpType) {
+                    //same fixed bump for all packages
+                    const version = conventionalCommits.incrementVersion(packageInfo.lastVersion, params.conventionalBumpType);
+                    packageInfo.recommendation = { reason: `fixed bump to "${params.conventionalBumpType}"` };
+                    packageInfo.version = version;
                 } else {
                     //from conventional commits which change files in this package
                     const { version, recommendation } = await conventionalCommits.getNextVersion(packageInfo.lastVersion, packageInfo.packagePath);

--- a/src/release/packageApi.js
+++ b/src/release/packageApi.js
@@ -129,6 +129,18 @@ export default function packageApiFactory(params = {}, data) {
          */
         async updateVersion() {
             await this.npmPackage.updateVersion(undefined, data.version);
+        },
+
+        async lernaGetPackagesList() {
+            return await this.npmPackage.lernaGetPackagesList();
+        },
+
+        async lernaUpdateVersions(packagesInfo) {
+            await this.npmPackage.lernaUpdateVersions(packagesInfo, data.version);
+        },
+
+        async lernaPublish() {
+            await this.npmPackage.lernaPublish();
         }
     };
 }

--- a/src/release/packageApi.js
+++ b/src/release/packageApi.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020-2021 Open Assessment Technologies SA;
+ * Copyright (c) 2020-2024 Open Assessment Technologies SA;
  */
 
 /**
@@ -131,15 +131,28 @@ export default function packageApiFactory(params = {}, data) {
             await this.npmPackage.updateVersion(undefined, data.version);
         },
 
-        async lernaGetPackagesList() {
+        /**
+         * For lerna monorepo, get list of packages
+         * @returns {Promise<Object[]>} - `[{ packageName: string, packagePath: string, lastVersion: string, dependencies: string[] }]`
+         */
+        async monorepoGetPackagesList() {
             return await this.npmPackage.lernaGetPackagesList();
         },
 
-        async lernaUpdateVersions(packagesInfo) {
+        /**
+         * For monorepo, update version in the root and in the packages
+         * @param {Object[]} packagesInfo - `[{packageName: string, packagePath: string, version: string}]`
+         * @returns {Promise<void>}
+         */
+        async monorepoUpdateVersions(packagesInfo) {
             await this.npmPackage.lernaUpdateVersions(packagesInfo, data.version);
         },
 
-        async lernaPublish() {
+        /**
+         * For lerna monorepo, publish packages to npm
+         * @returns {Promise<void>}
+         */
+        async monorepoPublish() {
             await this.npmPackage.lernaPublish();
         }
     };

--- a/tests/unit/conventionalCommits.spec.js
+++ b/tests/unit/conventionalCommits.spec.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2023 Open Assessment Technologies SA;
+ * Copyright (c) 2023-2024 Open Assessment Technologies SA;
  */
 
 import conventionalCommits from '../../src/conventionalCommits';
@@ -31,7 +31,7 @@ jest.mock('conventional-changelog-core', () => {
                 if (e === 'end') {
                     callback();
                 }
-        
+
                 return this;
             }
         }))
@@ -76,26 +76,33 @@ describe('src/conventionalCommits.js', () => {
     it('the conventional commits instance has a getNextVersion method', () => {
         expect(typeof conventionalCommits.getNextVersion).toBe('function');
     });
+    it('the conventional commits instance has a getVersionFromTag method', () => {
+        expect(typeof conventionalCommits.getVersionFromTag).toBe('function');
+    });
     it('should parse last tag and increment', async () => {
         const lastTag = '1.2.3';
-        const results = await conventionalCommits.getNextVersion(lastTag);
+        const lastVersion = conventionalCommits.getVersionFromTag(lastTag);
+        expect(lastVersion).toBe('1.2.3');
+        const results = await conventionalCommits.getNextVersion(lastVersion);
         expect(results.version).toBe('1.3.0');
-        expect(results.lastVersion).toBe('1.2.3');
     });
     it('should coerce and increment a bad tag', async () => {
         const lastTag = '3.2.5.8';
-        const results = await conventionalCommits.getNextVersion(lastTag);
+        const lastVersion = conventionalCommits.getVersionFromTag(lastTag);
+        expect(lastVersion).toBe('3.2.5');
+        const results = await conventionalCommits.getNextVersion(lastVersion);
         expect(results.version).toBe('3.3.0');
-        expect(results.lastVersion).toBe('3.2.5');
     });
     it('should coerce version with a pre-release', async () => {
         const lastTag = '4.12.13-8';
-        const results = await conventionalCommits.getNextVersion(lastTag);
+        const lastVersion = conventionalCommits.getVersionFromTag(lastTag);
+        expect(lastVersion).toBe('4.12.13');
+        const results = await conventionalCommits.getNextVersion(lastVersion);
         expect(results.version).toBe('4.13.0');
-        expect(results.lastVersion).toBe('4.12.13');
     });
     it('fails when the last cannot be parsed', async () => {
-        expect.assertions(1);
-        await expect(conventionalCommits.getNextVersion('foo')).rejects.toEqual(TypeError('Unable to retrieve last version from tags or the last tag is not semver compliant'));
+        expect.assertions(2);
+        expect(() => conventionalCommits.getVersionFromTag('foo')).toThrow(TypeError('Unable to retrieve last version from tags or the last tag "foo" is not semver compliant'));
+        await expect(conventionalCommits.getNextVersion('foo')).rejects.toEqual(Error('Last version "foo" is not semver compliant'));
     });
 });

--- a/tests/unit/npmPackage.spec.js
+++ b/tests/unit/npmPackage.spec.js
@@ -90,14 +90,14 @@ describe('src/npmPackage.js', () => {
         expect.assertions(2);
         expect(typeof npmPackage.npmCommand).toBe('function');
         expect(npmPackage.npmCommand()).rejects.toEqual(
-            TypeError('Invalid argument type: undefined for npmCommand (should be string)')
+            TypeError('Invalid argument type: npm/npx command: "npmNpx" and "command" arguments should be string')
         );
     });
 
     it('npmCommand should reject on invalid params', () => {
         expect.assertions(1);
         return expect(npmPackage.npmCommand(['my', 'command'])).rejects.toEqual(
-            TypeError('Invalid argument type: object for npmCommand (should be string)')
+            TypeError('Invalid argument type: npm/npx command: "npmNpx" and "command" arguments should be string')
         );
     });
 


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-5972

- [ ] after this is merged, test LDS github action https://github.com/oat-sa/live-design-system/pull/1159
- [ ] after this is merged, update readme in LDS & tao-deliver-fe & pisa-deliver-fe

### Changes:
1. Add  command to release [live-design-system](https://github.com/oat-sa/live-design-system) from github action:
```
taoRelease npmReleaseMonorepo
```
Sample run: [release tag](https://github.com/olga-kulish/live-design-system/releases/tag/v22.1.0) and [release PR](https://github.com/olga-kulish/live-design-system/pull/22) and [action run](https://github.com/olga-kulish/live-design-system/actions/runs/8001375114) (fails intentionally, because there's no publish permission on that npm token)

2. _[optional]_ use it also for monthly [tao-deliver-fe](https://github.com/oat-sa/tao-deliver-fe) release:
```
taoRelease npmReleaseMonorepo --base-branch release-2024-03 --release-branch main --release-tag 2024.03 --conventional-bump-type minor
```

### Notes:
1. Here, calculating version for packages, and then updating package.json & package-lock.json, is done manually. But it can be done with `npx lerna version`, just need to create dummy tags and pass additional arguments. See: https://github.com/oat-sa/tao-extension-release/compare/develop...feature/TR-5972/monorepo-release-npx-lerna-version . We can use that version if you prefer, just for me it looked kind of clearer to do all that manually.
2. New options `--release-tag` and `--conventional-bump-type` are added for the sake of tao-deliver-fe. Not sure if it helps any way, may be we should just continue doing all that manually. And user must still not forget to merge `main` to `develop` manually.
4. Hotfixes must still be done manually, both in live-design-system and tao-deliver-fe. I thought new options could help, but no, it requires more changes.

### How to test
1. Checkout this branch, do `npm link` form the root of this repo. Then call `taoRelease ...` from the repo which you want to release. Npm packages can be published dummy local registry with _verdaccio_.
2. Or experiment with this fork repository: https://github.com/olga-kulish/live-design-system . It has test release action: https://github.com/olga-kulish/live-design-system/actions/workflows/release-packages.yml . Since it's a fork, it uses a [test branch with repo url override](https://github.com/oat-sa/tao-extension-release/compare/feature/TR-5972/monorepo-release-custom-versioning...feature/TR-5972/monorepo-release-custom-versioning-test).
3. To debug which commits are used to do convenional bump:
     - https://github.com/conventional-changelog/conventional-changelog/blob/conventional-recommended-bump-v6.1.0/packages/conventional-recommended-bump/index.js#L75-L80
     - https://github.com/conventional-changelog/conventional-changelog/blob/git-semver-tags%404.1.1/packages/git-semver-tags/index.js#L7
     - (it checks diff between latest tag on currently checked out branch and head of the branch)
4. To debug how it gets latest tag from which it extracts root version:
    - https://github.com/steveukx/git-js/blob/simple-git%403.17.0/simple-git/src/lib/responses/TagList.ts#L7-L33
    - (it looks for tag with biggest semver version, across all branches. Uses custom semver parsing)