### PR TITLE
Fix/tr 5972/npm release monorepo: comment if changes only in root

### DIFF
--- a/src/release.js
+++ b/src/release.js
@@ -767,11 +767,13 @@ export default function taoExtensionReleaseFactory(params = {}) {
                 } else {
                     //from conventional commits which change files in this package
                     const { version, recommendation } = await conventionalCommits.getNextVersion(packageInfo.lastVersion, packageInfo.packagePath);
+                    packageInfo.recommendation = recommendation;
                     if (recommendation.stats && recommendation.stats.commits === 0) {
                         packageInfo.noChanges = true;
+                        packageInfo.version = packageInfo.lastVersion;
+                    } else {
+                        packageInfo.version = version;
                     }
-                    packageInfo.recommendation = recommendation;
-                    packageInfo.version = version;
                 }
             }
 

--- a/src/release/packageApi.js
+++ b/src/release/packageApi.js
@@ -89,11 +89,11 @@ export default function packageApiFactory(params = {}, data) {
         },
 
         /**
-         * Checkout master, show a prompt and then run `npm publish`
-         * TODO: checkout latest tag?
+         * Checkout master,
+         * Prompt user whether he wants to publish packages
          * @returns {Promise}
          */
-        async publish() {
+        async beforePublish() {
             if (this.gitClient) {
                 await this.gitClient.checkout(params.releaseBranch);
             }
@@ -113,6 +113,16 @@ export default function packageApiFactory(params = {}, data) {
                 });
                 publishPackage = confirmPublish;
             }
+            return publishPackage;
+        },
+
+        /**
+         * Checkout master, show a prompt and then run `npm publish`
+         * TODO: checkout latest tag?
+         * @returns {Promise}
+         */
+        async publish() {
+            const publishPackage = await this.beforePublish();
             if (publishPackage)     {
                 log.doing(`Publishing package ${this.npmPackage.name} @ ${this.npmPackage.version}`);
                 return this.npmPackage.publish();
@@ -153,7 +163,10 @@ export default function packageApiFactory(params = {}, data) {
          * @returns {Promise<void>}
          */
         async monorepoPublish() {
-            await this.npmPackage.lernaPublish();
+            const publishPackage = await this.beforePublish();
+            if (publishPackage)     {
+                return this.npmPackage.lernaPublish();
+            }
         }
     };
 }

--- a/src/release/packageApi.js
+++ b/src/release/packageApi.js
@@ -91,7 +91,7 @@ export default function packageApiFactory(params = {}, data) {
         /**
          * Checkout master,
          * Prompt user whether he wants to publish packages
-         * @returns {Promise}
+         * @returns {Promise<Boolean>}
          */
         async beforePublish() {
             if (this.gitClient) {
@@ -164,7 +164,8 @@ export default function packageApiFactory(params = {}, data) {
          */
         async monorepoPublish() {
             const publishPackage = await this.beforePublish();
-            if (publishPackage)     {
+            if (publishPackage) {
+                log.doing('Publishing monorepo packages');
                 return this.npmPackage.lernaPublish();
             }
         }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-5972

1) Before publishing should checkout+pull `master`. Now it publishes from `release-1.2.3` branch (should be no real difference though). Also let's prompt user for consistency with usual `npmRelease`.

![Screenshot_32](https://github.com/oat-sa/tao-extension-release/assets/38751932/ed605562-aa0e-4a17-9d4d-851fe4526011)

![Screenshot_33](https://github.com/oat-sa/tao-extension-release/assets/38751932/fba6e474-d66b-47d4-842a-c17f841e2f76)

------------------------

2) Edge case: if changes are only in the root, then PR comment will contain version bump that wasn't actually committed.

Sample run with fix: https://github.com/olga-kulish/live-design-system/pull/26 and https://github.com/olga-kulish/live-design-system/releases/tag/v22.1.2 . Orignal case: https://github.com/oat-sa/live-design-system/pull/1177 and its PR comment:

![Screenshot_27](https://github.com/oat-sa/tao-extension-release/assets/38751932/212ebe42-8a18-41b7-8e8a-5f5d4c5012d8)
