### PR TITLE
Fix/tr 5972/npmRelease skipped publish step

### DIFF
--- a/src/commands/npmRelease.js
+++ b/src/commands/npmRelease.js
@@ -36,6 +36,7 @@ program
     .option(...cliOptions.releaseBranch)
     .option(...cliOptions.noInteractive)
     .option(...cliOptions.noWrite)
+    .option(...cliOptions.noPublish)
 
     // options which fall back to user prompts if undefined
     .option(...cliOptions.releaseComment)


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-5972

One more fix...

`taoRelease npmRelease` lost its publish step, because `--no-publish` parameter was added in https://github.com/oat-sa/tao-extension-release/pull/125, but it was passed to `release.js` only in `npmReleaseMonorepo`.

![Screenshot_36](https://github.com/oat-sa/tao-extension-release/assets/38751932/7be2b534-0127-4ca0-9065-2c0730561f47)
