### PR TITLE
fix: suppress error deleting branch in case it already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ So the command `taoRelease` will use the sources.
 Useful commands :
 
 - `npm test` runs the test suite
+- `npx jest -- my-test.spec.js` runs a single test
 - `npm run test:cov` runs the test suite with code coverage
 - `npm run test:dev` runs the test suite in watch mode
 - `npm run lint` verifies the sources complies with the code style guide

--- a/src/release.js
+++ b/src/release.js
@@ -615,11 +615,11 @@ export default function taoExtensionReleaseFactory(params = {}) {
 
             try {
                 await gitClient.deleteBranch(data.releasingBranch);   
-            } catch (e) {
-                if (e.message.contains('remote ref does not exist')) {
-                    log.warn(`Error deleting branch ${data.releasingBranch}: ${e} - ${e.stack}`);
+            } catch (error) {
+                if (error.message.includes('remote ref does not exist')) {
+                    log.warn(`Cannot delete branch ${data.releasingBranch}: ${error} - ${error.stack}`);
                 } else {
-                    throw e;
+                    throw error;
                 }
             }
 

--- a/src/release.js
+++ b/src/release.js
@@ -613,7 +613,15 @@ export default function taoExtensionReleaseFactory(params = {}) {
         async removeReleasingBranch() {
             log.doing('Clean up the place');
 
-            await gitClient.deleteBranch(data.releasingBranch);
+            try {
+                await gitClient.deleteBranch(data.releasingBranch);   
+            } catch (e) {
+                if (e.message.contains('remote ref does not exist')) {
+                    log.warn(`Error deleting branch ${data.releasingBranch}: ${e} - ${e.stack}`);
+                } else {
+                    throw e;
+                }
+            }
 
             log.done();
         },

--- a/tests/unit/release/removeReleasingBranch/release.spec.js
+++ b/tests/unit/release/removeReleasingBranch/release.spec.js
@@ -104,12 +104,10 @@ describe('src/release.js removeReleasingBranch', () => {
         const deleteBranch = jest.fn();
 
         deleteBranch.mockImplementationOnce(() => {
-            //Mock the default export
             throw new Error('remote ref does not exist');
         });
 
         git.mockImplementationOnce(() => {
-            //Mock the default export
             return {
                 deleteBranch
             };
@@ -129,12 +127,10 @@ describe('src/release.js removeReleasingBranch', () => {
         const deleteBranch = jest.fn();
 
         deleteBranch.mockImplementationOnce(() => {
-            //Mock the default export
             throw new Error('Some other error');
         });
 
         git.mockImplementationOnce(() => {
-            //Mock the default export
             return {
                 deleteBranch
             };


### PR DESCRIPTION
# Goal 

Avoid crashing release of extensions in case the branch was already deleted by new OAT policy

Example of error

https://github.com/oat-sa/extension-tao-deliver-connect/actions/runs/9581996092/job/26420009190

```
error: unable to delete 'release-5.22.0': remote ref does not exist
error: failed to push some refs to 'https://***@github.com/oat-sa/extension-tao-deliver-connect.git'
```

![Screenshot 2024-06-19 at 14 47 18](https://github.com/oat-sa/tao-extension-release/assets/1467589/e46b8211-3112-4678-b3c6-63cd0c5684bf)
