### PR TITLE
Fix/recover from failed branch deletions

### DIFF
--- a/src/release.js
+++ b/src/release.js
@@ -614,9 +614,11 @@ export default function taoExtensionReleaseFactory(params = {}) {
             log.doing('Clean up the place');
 
             try {
-                await gitClient.deleteBranch(data.releasingBranch);   
+                await gitClient.deleteBranch(data.releasingBranch);
             } catch (error) {
-                if (error.message.includes('remote ref does not exist')) {
+                // If a github setting auto-deleted the closed PR branch on the remote before this step,
+                // these are some of the observed error messages
+                if (error.message.includes('remote ref does not exist') || error.message.includes('unable to resolve reference')) {
                     log.warn(`Cannot delete branch ${data.releasingBranch}: ${error} - ${error.stack}`);
                 } else {
                     throw error;


### PR DESCRIPTION
Follow-up to https://github.com/oat-sa/tao-extension-release/pull/134

I noticed our `release-packages.yml` workflow failing in a few places:

1. eslint-config-tao [error in run](https://github.com/oat-sa/eslint-config-tao/actions/runs/10793376619/job/29935154252), blocked NPM publish
```
➡ Clean up the place
Error: Error: To https://github.com/oat-sa/eslint-config-tao
!	:refs/heads/release-4.0.0	[remote rejected] (cannot lock ref 'refs/heads/release-4.0.0': unable to resolve reference 'refs/heads/release-4.0.0')
❎ To https://github.com/oat-sa/eslint-config-tao
Done
Pushing to https://github.com/oat-sa/eslint-config-tao
POST git-receive-pack (1[88](https://github.com/oat-sa/eslint-config-tao/actions/runs/10793376619/job/29935154252#step:4:89) bytes)
error: failed to push some refs to 'https://github.com/oat-sa/eslint-config-tao'
!	:refs/heads/release-4.0.0	[remote rejected] (cannot lock ref 'refs/heads/release-4.0.0': unable to resolve reference 'refs/heads/release-4.0.0')
Done
```

2. read-aloud-client-fe [error in run](https://github.com/oat-sa/read-aloud-client-fe/actions/runs/10807876854/job/29979625157), blocked NPM publish
```
➡ Clean up the place
❎ To https://github.com/oat-sa/read-aloud-client-fe
!	:refs/heads/release-0.9.0	[remote rejected] (cannot lock ref 'refs/heads/release-0.9.0': unable to resolve reference 'refs/heads/release-0.9.0')
Error: Error: To https://github.com/oat-sa/read-aloud-client-fe
!	:refs/heads/release-0.9.0	[remote rejected] (cannot lock ref 'refs/heads/release-0.9.0': unable to resolve reference 'refs/heads/release-0.9.0')
Done
Pushing to https://github.com/oat-sa/read-aloud-client-fe
POST git-receive-pack (188 bytes)
error: failed to push some refs to 'https://github.com/oat-sa/read-aloud-client-fe'

Done
```

3. live-design-system [error in run](https://github.com/oat-sa/live-design-system/actions/runs/10791927825/job/29930436352)
```
➡ Clean up the place
⚠ Cannot delete branch release-21.3.0: Error: Pushing to https://github.com/oat-sa/live-design-system
error: unable to delete 'release-21.3.0': remote ref does not exist
error: failed to push some refs to 'https://github.com/oat-sa/live-design-system'
 - Error: Pushing to https://github.com/oat-sa/live-design-system
error: unable to delete 'release-21.3.0': remote ref does not exist
error: failed to push some refs to 'https://github.com/oat-sa/live-design-system'
```

Based on the error messages, I think it could be the same problem that was addressed in #134 (but we should catch more error messages than we do).

This PR is a bit of a shot in the dark (untested). Looking for a second opinion before propagating to one of the broken workflows.