### PR TITLE
fix: improve validating if release branch is already created

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -112,6 +112,21 @@ export default function gitFactory(repository = '', origin = 'origin') {
         },
 
         /**
+         * Delete a local branch only.
+         * @param {String} branchName - the branch name
+         * @returns {Promise}
+         */
+        deleteLocalBranch(branchName){
+            return git(repository).deleteLocalBranch(branchName)
+                .then( results => {
+                    if (results.success){
+                        results.branch = branchName;
+                    }
+                    return results;
+                });
+        },
+
+        /**
          * Create and checkout a local branch
          * @param {String} branchName - the branch name
          * @returns {Promise}

--- a/src/github.js
+++ b/src/github.js
@@ -359,6 +359,15 @@ export default function githubFactory(token, repository) {
                 })
                 .map(this.formatReleaseNote)
                 .reduce((acc, note) => note ? `${acc} - ${note}\n` : acc, '');
+        },
+
+        /**
+         * Search for pull requests using GitHub GraphQL API
+         * @param {String} searchQuery - GitHub search query
+         * @returns {Promise<Object>} resolves with search results
+         */
+        searchPullRequests(searchQuery) {
+            return githubApiClient.searchPullRequests(searchQuery);
         }
     };
 }

--- a/src/release.js
+++ b/src/release.js
@@ -251,15 +251,67 @@ export default function taoExtensionReleaseFactory(params = {}) {
                 ].join('\n');
             }
 
-            await githubClient.release(data.tag, fullReleaseComment);
+            try {
+                await githubClient.release(data.tag, fullReleaseComment);
+                log.done();
+            } catch (err) {
+                // If release already exists, log a warning and continue
+                if (err.message && (err.message.includes('already exists') || err.message.includes('Validation Failed'))) {
+                    log.warn(`GitHub release for tag ${data.tag} already exists. Skipping release creation.`);
+                    log.done();
+                } else {
+                    throw err;
+                }
+            }
+        },
 
-            log.done();
+        /**
+         * Find existing pull request for the release branch
+         */
+        async findExistingPullRequest() {
+            if (!githubClient || !data.releasingBranch) {
+                return false;
+            }
+
+            try {
+                const metadata = await this.getMetadata();
+                if (!metadata || !metadata.repoName) {
+                    return false;
+                }
+
+                const searchQuery = `repo:${metadata.repoName} head:${data.releasingBranch} base:${params.releaseBranch} type:pr state:open`;
+                
+                const result = await githubClient.searchPullRequests(searchQuery);
+                if (result && result.search && result.search.nodes && result.search.nodes.length > 0) {
+                    const pr = result.search.nodes[0];
+                    data.pr = {
+                        url: pr.url,
+                        apiUrl: pr.url,
+                        number: pr.number,
+                        id: pr.number,
+                        full_name: metadata.repoName,
+                    };
+                    log.info(`Found existing PR: ${pr.url}`);
+                    return true;
+                }
+            } catch (err) {
+                log.warn(`Could not search for existing PR: ${err.message}`);
+            }
+            return false;
         },
 
         /**
          * Create release pull request from releasing branch
          */
         async createPullRequest() {
+            // If PR already exists, skip creation
+            if (data.pr && data.pr.number) {
+                log.doing('Using existing pull request');
+                log.info(`${data.pr.url} already exists`);
+                log.done();
+                return;
+            }
+
             log.doing('Create the pull request');
 
             try {
@@ -286,6 +338,16 @@ export default function taoExtensionReleaseFactory(params = {}) {
                     log.exit('Unable to create the release pull request');
                 }
             } catch (err) {
+                // If PR already exists, try to find it
+                if (err.message && (err.message.includes('already exists') || err.message.includes('pull request already exists'))) {
+                    log.warn('Pull request might already exist, trying to find it...');
+                    const found = await this.findExistingPullRequest();
+                    if (found) {
+                        log.done();
+                        return;
+                    }
+                }
+                
                 log.error(
                     'There are errors on the pull request creation, things like: '
                     + 'the repository name and/or local changes that could prevent the PR '
@@ -303,6 +365,13 @@ export default function taoExtensionReleaseFactory(params = {}) {
          * Create and publish release tag
          */
         async createReleaseTag() {
+            // Skip if tag already exists
+            if (data.tagExists) {
+                log.doing(`Tag ${data.tag} already exists, skipping tag creation`);
+                log.done();
+                return;
+            }
+
             log.doing(`Add and push tag ${data.tag}`);
 
             await gitClient.tag(params.releaseBranch, data.tag, `version ${data.version}`);
@@ -314,12 +383,62 @@ export default function taoExtensionReleaseFactory(params = {}) {
          * Create releasing branch
          */
         async createReleasingBranch() {
-            log.doing('Create release branch');
+            if (data.releasingBranchExists) {
+                // Instead of reusing, create a new branch with retry suffix
+                log.doing(`Release branch ${data.releasingBranch} already exists. Creating a new branch with retry suffix.`);
+                
+                const retryNumber = await this.findNextRetryBranchNumber();
+                const originalBranch = data.releasingBranch;
+                data.releasingBranch = `${originalBranch}-retry-${retryNumber}`;
+                
+                log.info(`Creating new branch: ${data.releasingBranch}`);
+                
+                // Create the new branch from the base branch
+                // Ensure we're on the latest version of the base branch
+                await gitClient.checkout(baseBranch);
+                await gitClient.pull(baseBranch);
+                await gitClient.localBranch(data.releasingBranch);
+                await gitClient.push(origin, data.releasingBranch);
+                
+                log.done(`${data.releasingBranch} created`);
+            } else {
+                log.doing('Create release branch');
 
-            await gitClient.localBranch(data.releasingBranch);
-            await gitClient.push(origin, data.releasingBranch);
+                await gitClient.localBranch(data.releasingBranch);
+                await gitClient.push(origin, data.releasingBranch);
 
-            log.done(`${data.releasingBranch} created`);
+                log.done(`${data.releasingBranch} created`);
+            }
+        },
+
+        /**
+         * Find the next available retry branch number
+         * Checks for existing branches matching the pattern: ${branchPrefix}-${version}-retry-*
+         * @returns {Promise<Number>} the next available retry number
+         */
+        async findNextRetryBranchNumber() {
+            const allBranches = await gitClient.getLocalBranches();
+            const baseBranchName = `${branchPrefix}-${data.version}`;
+            // Escape special regex characters in the base branch name
+            // Use a regular string for the character class to avoid template literal interpretation
+            const escapedBaseBranchName = baseBranchName.replace(/[.*+?^$()|[\]\\]/g, '\\$&').replace(/{/g, '\\{').replace(/}/g, '\\}');
+            const retryPattern = new RegExp('^' + escapedBaseBranchName + '-retry-(\\d+)$');
+            
+            let maxRetryNumber = 0;
+            
+            for (const branch of allBranches) {
+                // Remove 'remotes/origin/' prefix if present for comparison
+                const branchName = branch.replace(/^remotes\/[^/]+\//, '');
+                const match = branchName.match(retryPattern);
+                if (match) {
+                    const retryNumber = parseInt(match[1], 10);
+                    if (retryNumber > maxRetryNumber) {
+                        maxRetryNumber = retryNumber;
+                    }
+                }
+            }
+            
+            return maxRetryNumber + 1;
         },
 
         /**
@@ -340,7 +459,10 @@ export default function taoExtensionReleaseFactory(params = {}) {
             log.doing(`Check if tag ${data.tag} exists`);
 
             if (await gitClient.hasTag(data.tag)) {
-                log.exit(`The tag ${data.tag} already exists`);
+                log.warn(`The tag ${data.tag} already exists. Will skip tag creation.`);
+                data.tagExists = true;
+            } else {
+                data.tagExists = false;
             }
 
             log.done();
@@ -353,7 +475,13 @@ export default function taoExtensionReleaseFactory(params = {}) {
             log.doing(`Check if branch remotes/${origin}/${data.releasingBranch} exists`);
 
             if (await gitClient.hasBranch(`remotes/${origin}/${data.releasingBranch}`)) {
-                log.exit(`The remote branch remotes/${origin}/${data.releasingBranch} already exists.`);
+                log.warn(`The remote branch remotes/${origin}/${data.releasingBranch} already exists. Will try to reuse it.`);
+                data.releasingBranchExists = true;
+                
+                // Try to find existing PR for this branch
+                await this.findExistingPullRequest();
+            } else {
+                data.releasingBranchExists = false;
             }
 
             log.done();
@@ -618,8 +746,23 @@ export default function taoExtensionReleaseFactory(params = {}) {
             } catch (error) {
                 // If a github setting auto-deleted the closed PR branch on the remote before this step,
                 // these are some of the observed error messages
-                if (error.message.includes('remote ref does not exist') || error.message.includes('unable to resolve reference')) {
-                    log.warn(`Cannot delete branch ${data.releasingBranch}: ${error} - ${error.stack}`);
+                const errorMessage = error.message || String(error);
+                if (errorMessage.includes('remote ref does not exist') || 
+                    errorMessage.includes('unable to resolve reference') ||
+                    (errorMessage.includes('unable to delete') && errorMessage.includes('remote ref does not exist'))) {
+                    log.warn(`Remote branch ${data.releasingBranch} was already deleted (likely by GitHub after PR merge).`);
+                    
+                    // Still try to delete the local branch if it exists
+                    try {
+                        const localBranches = await gitClient.getLocalBranches();
+                        if (localBranches.includes(data.releasingBranch)) {
+                            await gitClient.deleteLocalBranch(data.releasingBranch);
+                            log.info(`Local branch ${data.releasingBranch} deleted.`);
+                        }
+                    } catch (localError) {
+                        // If local branch deletion fails, it's not critical
+                        log.warn(`Could not delete local branch ${data.releasingBranch}: ${localError.message}`);
+                    }
                 } else {
                     throw error;
                 }

--- a/tests/unit/release/createReleasingBranch/release.spec.js
+++ b/tests/unit/release/createReleasingBranch/release.spec.js
@@ -46,7 +46,10 @@ jest.mock('../../../../src/git.js', () => {
             hasTag: jest.fn(),
             getLastTag: jest.fn(),
             hasDiff:  jest.fn(() => true),
-            mergeBack: jest.fn()
+            mergeBack: jest.fn(),
+            checkout: jest.fn(),
+            pull: jest.fn(),
+            getLocalBranches: jest.fn(() => [])
         }))
     };
 });
@@ -117,5 +120,87 @@ describe('src/release.js createReleasingBranch', () => {
     
         expect(log.done).toBeCalledTimes(1);
         expect(log.done).toBeCalledWith(`${branchPrefix}-${version} created`);
+    });
+
+    test('should create retry branch when branch already exists', async () => {
+        expect.assertions(7);
+    
+        const localBranchMock = jest.fn(() => true);
+        const pushMock = jest.fn(() => true);
+        const checkoutMock = jest.fn(() => true);
+        const pullMock = jest.fn(() => true);
+        const getLocalBranchesMock = jest.fn(() => []);
+        
+        git.mockImplementationOnce(() => {
+            return {
+                localBranch: localBranchMock,
+                push: pushMock,
+                checkout: checkoutMock,
+                pull: pullMock,
+                getLocalBranches: getLocalBranchesMock
+            };
+        });
+
+        const release = releaseFactory({ branchPrefix, origin, baseBranch: 'develop' });
+        release.setData({ 
+            releasingBranch, 
+            version, 
+            tag, 
+            token, 
+            extension: {},
+            releasingBranchExists: true
+        });
+        await release.initialiseGitClient();
+        await release.createReleasingBranch();
+    
+        expect(checkoutMock).toBeCalledTimes(1);
+        expect(checkoutMock).toBeCalledWith('develop');
+        expect(pullMock).toBeCalledTimes(1);
+        expect(pullMock).toBeCalledWith('develop');
+        expect(getLocalBranchesMock).toBeCalledTimes(1);
+        expect(localBranchMock).toBeCalledWith(`${branchPrefix}-${version}-retry-1`);
+        expect(pushMock).toBeCalledWith('origin', `${branchPrefix}-${version}-retry-1`);
+    });
+
+    test('should find next retry number when retry branches exist', async () => {
+        expect.assertions(1);
+    
+        const getLocalBranchesMock = jest.fn(() => [
+            'release-1.1.1-retry-1',
+            'remotes/origin/release-1.1.1-retry-2',
+            'release-1.1.1-retry-3'
+        ]);
+        
+        git.mockImplementationOnce(() => {
+            return {
+                getLocalBranches: getLocalBranchesMock,
+                checkout: jest.fn(),
+                pull: jest.fn(),
+                localBranch: jest.fn(),
+                push: jest.fn()
+            };
+        });
+
+        const release = releaseFactory({ branchPrefix, origin, baseBranch: 'develop' });
+        release.setData({ 
+            releasingBranch, 
+            version, 
+            tag, 
+            token, 
+            extension: {},
+            releasingBranchExists: true
+        });
+        await release.initialiseGitClient();
+        await release.createReleasingBranch();
+    
+        // Should create retry-4 since retry-1, retry-2, and retry-3 exist
+        expect(release.getData().releasingBranch).toBe(`${branchPrefix}-${version}-retry-4`);
+    });
+
+    test('should define findNextRetryBranchNumber method on release instance', () => {
+        expect.assertions(1);
+
+        const release = releaseFactory({ branchPrefix, origin });
+        expect(typeof release.findNextRetryBranchNumber).toBe('function');
     });
 });

--- a/tests/unit/release/doesReleasingBranchExists/release.spec.js
+++ b/tests/unit/release/doesReleasingBranchExists/release.spec.js
@@ -102,10 +102,11 @@ describe('src/release.js doesReleasingBranchExists', () => {
         expect(hasBranch).toBeCalledWith(`remotes/${origin}/${branchPrefix}-${version}`);
     });
 
-    test('should log exit if release branch exists', async () => {
-        expect.assertions(2);
+    test('should log warn and set flag if release branch exists', async () => {
+        expect.assertions(3);
 
         const hasBranch = jest.fn(() => true);
+        const findExistingPullRequest = jest.fn();
         git.mockImplementationOnce(() => {
             //Mock the default export
             return {
@@ -115,11 +116,13 @@ describe('src/release.js doesReleasingBranchExists', () => {
 
         const release = releaseFactory({ branchPrefix, origin });
         release.setData({ releasingBranch, version, tag, token, extension: {} });
+        release.findExistingPullRequest = findExistingPullRequest;
         await release.initialiseGitClient();
         await release.doesReleasingBranchExists();
 
-        expect(log.exit).toBeCalledTimes(1);
-        expect(log.exit).toBeCalledWith(`The remote branch remotes/${origin}/${branchPrefix}-${version} already exists.`);
+        expect(log.warn).toBeCalledWith(`The remote branch remotes/${origin}/${branchPrefix}-${version} already exists. Will try to reuse it.`);
+        expect(release.getData().releasingBranchExists).toBe(true);
+        expect(findExistingPullRequest).toBeCalledTimes(1);
     });
 
     test('should log done message', async () => {

--- a/tests/unit/release/doesTagExists/release.spec.js
+++ b/tests/unit/release/doesTagExists/release.spec.js
@@ -98,8 +98,8 @@ describe('src/release.js doesTagExists', () => {
         expect(hasTag).toBeCalledWith(`v${version}`);
     });
     
-    test('should log exit if tag exists', async () => {
-        expect.assertions(2);
+    test('should log warn and set flag if tag exists', async () => {
+        expect.assertions(3);
     
         const hasTag = jest.fn(() => true);
         git.mockImplementationOnce(() => {
@@ -114,8 +114,9 @@ describe('src/release.js doesTagExists', () => {
         await release.initialiseGitClient();
         await release.doesTagExists();
     
-        expect(log.exit).toBeCalledTimes(1);
-        expect(log.exit).toBeCalledWith(`The tag v${version} already exists`);
+        expect(log.warn).toBeCalledTimes(1);
+        expect(log.warn).toBeCalledWith(`The tag ${tag} already exists. Will skip tag creation.`);
+        expect(release.getData().tagExists).toBe(true);
     });
     
     test('should log done message', async () => {

--- a/tests/unit/release/removeReleasingBranch/release.spec.js
+++ b/tests/unit/release/removeReleasingBranch/release.spec.js
@@ -47,11 +47,13 @@ jest.mock('../../../../src/git.js', () => {
             merge: jest.fn(),
             mergePr: jest.fn(),
             getLocalBranches: jest.fn(() => []),
-            checkoutNonLocal: jest.fn()
+            checkoutNonLocal: jest.fn(),
+            deleteLocalBranch: jest.fn()
         }))
     };
 });
 
+import log from '../../../../src/log.js';
 import git from '../../../../src/git.js';
 import releaseFactory from '../../../../src/release.js';
 
@@ -99,9 +101,11 @@ describe('src/release.js removeReleasingBranch', () => {
         expect(deleteBranch).toBeCalledWith(`${branchPrefix}-${version}`);
     });
     test('should bypass error deleting release branch when it does not exist', async () => {
-        expect.assertions(4);
+        expect.assertions(6);
 
         const deleteBranch = jest.fn();
+        const getLocalBranches = jest.fn(() => []);
+        const deleteLocalBranch = jest.fn();
 
         deleteBranch.mockImplementationOnce(() => {
             throw new Error('remote ref does not exist');
@@ -111,7 +115,9 @@ describe('src/release.js removeReleasingBranch', () => {
 
         git.mockImplementation(() => {
             return {
-                deleteBranch
+                deleteBranch,
+                getLocalBranches,
+                deleteLocalBranch
             };
         });
 
@@ -122,13 +128,73 @@ describe('src/release.js removeReleasingBranch', () => {
 
         expect(deleteBranch).toBeCalledTimes(1);
         expect(deleteBranch).toBeCalledWith(`${branchPrefix}-${version}`);
+        expect(getLocalBranches).toBeCalledTimes(1);
+        expect(log.warn).toBeCalledWith(expect.stringContaining('Remote branch'));
 
         deleteBranch.mockClear();
+        getLocalBranches.mockClear();
 
         await release.removeReleasingBranch();
 
         expect(deleteBranch).toBeCalledTimes(1);
         expect(deleteBranch).toBeCalledWith(`${branchPrefix}-${version}`);
+    });
+
+    test('should delete local branch when remote branch was already deleted', async () => {
+        expect.assertions(4);
+
+        const deleteBranch = jest.fn(() => {
+            throw new Error('error: unable to delete \'release-1.1.1\': remote ref does not exist');
+        });
+        const getLocalBranches = jest.fn(() => ['release-1.1.1']);
+        const deleteLocalBranch = jest.fn(() => Promise.resolve({ success: true, branch: 'release-1.1.1' }));
+
+        git.mockImplementationOnce(() => {
+            return {
+                deleteBranch,
+                getLocalBranches,
+                deleteLocalBranch
+            };
+        });
+
+        const release = releaseFactory(branchPrefix);
+        release.setData({ releasingBranch, token, extension: {} });
+        await release.initialiseGitClient();
+        await release.removeReleasingBranch();
+
+        expect(deleteBranch).toBeCalledTimes(1);
+        expect(getLocalBranches).toBeCalledTimes(1);
+        expect(deleteLocalBranch).toBeCalledTimes(1);
+        expect(deleteLocalBranch).toBeCalledWith(`${branchPrefix}-${version}`);
+    });
+
+    test('should handle error when deleting local branch fails', async () => {
+        expect.assertions(3);
+
+        const deleteBranch = jest.fn(() => {
+            throw new Error('error: unable to delete \'release-1.1.1\': remote ref does not exist');
+        });
+        const getLocalBranches = jest.fn(() => ['release-1.1.1']);
+        const deleteLocalBranch = jest.fn(() => {
+            throw new Error('Local branch deletion failed');
+        });
+
+        git.mockImplementationOnce(() => {
+            return {
+                deleteBranch,
+                getLocalBranches,
+                deleteLocalBranch
+            };
+        });
+
+        const release = releaseFactory(branchPrefix);
+        release.setData({ releasingBranch, token, extension: {} });
+        await release.initialiseGitClient();
+        await release.removeReleasingBranch();
+
+        expect(deleteBranch).toBeCalledTimes(1);
+        expect(deleteLocalBranch).toBeCalledTimes(1);
+        expect(log.warn).toBeCalledWith(expect.stringContaining('Could not delete local branch'));
     });
     test('should not bypass error deleting release branch when another error', async () => {
         expect.assertions(3);


### PR DESCRIPTION
Improve validating if:
 - release branch is already created
 - release PR is already created
 
<img width="2141" height="686" alt="image" src="https://github.com/user-attachments/assets/186cf63d-b556-424e-ab63-02aed27605f6" />

 
<img width="1302" height="628" alt="image" src="https://github.com/user-attachments/assets/e6a7d814-d4e6-4e71-8483-c1769c9dcf89" />
